### PR TITLE
feat: support fetching OIDC userinfo from remote userinfo endpoint

### DIFF
--- a/src/runtime/schemes/openIDConnect.ts
+++ b/src/runtime/schemes/openIDConnect.ts
@@ -12,6 +12,7 @@ export interface OpenIDConnectSchemeEndpoints extends Oauth2SchemeEndpoints {
 }
 
 export interface OpenIDConnectSchemeOptions extends Oauth2SchemeOptions, IdTokenableSchemeOptions {
+    fetchRemote: boolean;
     endpoints: OpenIDConnectSchemeEndpoints;
 }
 
@@ -26,6 +27,7 @@ const DEFAULTS: SchemePartialOptions<OpenIDConnectSchemeOptions> = {
         prefix: '_id_token.',
         expirationPrefix: '_id_token_expiration.',
     },
+    fetchRemote: false,
     codeChallengeMethod: 'S256',
 };
 
@@ -154,7 +156,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
             return;
         }
 
-        if (this.idToken.get()) {
+        if (! this.options.fetchRemote && this.idToken.get()) {
             const data = this.idToken.userInfo();
             this.$auth.setUser(data);
             return;

--- a/src/runtime/schemes/openIDConnect.ts
+++ b/src/runtime/schemes/openIDConnect.ts
@@ -156,7 +156,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
             return;
         }
 
-        if (! this.options.fetchRemote && this.idToken.get()) {
+        if (!this.options.fetchRemote && this.idToken.get()) {
             const data = this.idToken.userInfo();
             this.$auth.setUser(data);
             return;


### PR DESCRIPTION
This PR aims to add support for forcing the OpenIDConnect scheme to fetch userinfo from the userinfo endpoint.

This is particularly useful when working with providers that do not update the ID token frequently (when using ory/hydra for example) or when using providers that supply too little information in the ID token in general.

Also see https://github.com/nuxt-community/auth-module/issues/1724 