### PR TITLE
fix: use crypto-js for synchronous sha265

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@pinia/nuxt": "latest",
         "body-parser": "latest",
         "cookie-es": "latest",
+        "crypto-js": "^4.1.1",
         "defu": "latest",
         "jwt-decode": "latest",
         "ohash": "latest",


### PR DESCRIPTION
@Teranode not sure if you think this is a good idea?

I noticed clientWindow does not work on Safari. After a bit of digging it became clear that it comes down to Safari loosing event context by the time `window.open` is actually called, so the popup gets blocked.
In order to properly get it working, all calls need to be synchronous, which is impossible with the native Web Crypto API.

I opted to use the same library that oidc-client-ts uses (https://github.com/authts/oidc-client-ts/blob/1d8254343748c367ef46e0992c510759ece990a2/src/utils/CryptoUtils.ts#L2).

Alternative PR is https://github.com/nuxt-alt/auth/pull/13