### PR TITLE
feat: support public runtime config strategy updates

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,6 +21,8 @@ export const getAuthPlugin = (options: {
 }): string => {
     return `import { Auth, ExpiredAuthSessionError } from '#auth/runtime'
 import { defineNuxtPlugin } from '#imports'
+import { defu } from 'defu';
+
 // Active schemes
 ${options.schemeImports.map((i) => `import { ${i.name}${i.name !== i.as ? ' as ' + i.as : ''} } from '${i.from}'`).join('\n')}
 
@@ -35,7 +37,7 @@ export default defineNuxtPlugin(nuxtApp => {
     ${options.strategies.map((strategy) => {
         const scheme = options.strategyScheme[strategy.name!]
         const schemeOptions = JSON.stringify(strategy, null, 2)
-        return `auth.registerStrategy('${strategy.name}', new ${scheme.as}(auth, ${schemeOptions}));`
+        return `auth.registerStrategy('${strategy.name}', new ${scheme.as}(auth, defu(useRuntimeConfig()?.public?.auth?.strategies?.['${strategy.name}'], ${schemeOptions})))`
     }).join(';\n')}
 
     nuxtApp.provide('auth', auth)
@@ -48,7 +50,7 @@ export default defineNuxtPlugin(nuxtApp => {
             if (error instanceof ExpiredAuthSessionError) {
                 return
             }
-        
+
             console.error('[ERROR] [AUTH]', error)
         }
     })


### PR DESCRIPTION
This PR aims to make strategies configurable at runtime. It adjusts the plugin template to merge the static strategy configuration from `nuxt.config.ts` with optional strategy configuration from the public runtime config.

Assuming the following nuxt.config.ts file:

```
export default defineNuxtConfig({
  auth: {
    strategies: {
      myStrategy: {
        scheme: 'openIDConnect',
      },
    },
  },
  runtimeConfig: {
    public: {
      auth: {
        strategies: {
          myStrategy: {
            clientId: '',
            endpoints: {
              configuration: '',
            },
          },
        },
      },
    },
  },
});
```

This would now allow you to configure things like the `clientId` for strategy `myStrategy` with an environment variable called `NUXT_PUBLIC_AUTH_STRATEGIES_MY_STRATEGY_CLIENT_ID`.

You can also adjust things like the configuration endpoint with this approach.

This is particularly useful for deployments where you need to change the client id depending on the environment. Development, Staging and Production environments would now be easily configurable by changing the `.env` file or environment.

This PR resolves https://github.com/nuxt-alt/auth/issues/2