### PR TITLE
fix: only react to loggedIn changes

### DIFF
--- a/src/runtime/core/auth.ts
+++ b/src/runtime/core/auth.ts
@@ -33,7 +33,7 @@ export class Auth {
             loggedIn: false
         };
 
-        const storage = new Storage(ctx, { 
+        const storage = new Storage(ctx, {
             ...options,
             initialState
         });
@@ -109,6 +109,7 @@ export class Auth {
         finally {
             if (process.client && this.options.watchLoggedIn) {
                 this.$storage.watchState('loggedIn', (loggedIn: boolean) => {
+                    if (this.$state.loggedIn === loggedIn) return;
                     if (Object.hasOwn(useRoute().meta, 'auth') && !routeMeta(useRoute(), 'auth', false)) {
                         this.redirect(loggedIn ? 'home' : 'logout');
                     }
@@ -339,7 +340,7 @@ export class Auth {
     }
 
     /**
-     * 
+     *
      * @param name redirect name
      * @param route (default: false) Internal useRoute() (false) or manually specify
      * @param router (default: true) Whether to use nuxt redirect (true) or window redirect (false)


### PR DESCRIPTION
Currently the loggedIn watcher reacts to any SET event on the store. This causes weird bugs when you have a scheme like cookie that always resets itself on login.
The following event timeline is true without this fix:

1. loggedIn = false
2. User calls auth.login()
3. reset happens, loggedIn = false
4. watcher kicks in and redirects to logout
5. user login takes place
6. user is set, loggedIn = true
7. watcher kicks in and redirects to home

With this PR the following would be true:

1. loggedIn = false
2. User calls auth.login()
3. reset happens, loggedIn = false
4. user login happens
5. user is set, loggedIn = true
6. watcher kicks in and redirects to home