### PR TITLE
fix: merge runtimeconfig recursively with module options

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -20,7 +20,7 @@ export default defineNuxtModule({
     defaults: moduleDefaults,
     async setup(moduleOptions, nuxt) {
         // Merge all option sources
-        const options: ModuleOptions = defu({ ...moduleOptions, ...nuxt.options.runtimeConfig[CONFIG_KEY] }, moduleDefaults)
+        const options: ModuleOptions = defu(nuxt.options.runtimeConfig[CONFIG_KEY], moduleOptions, moduleDefaults)
 
         // Resolver
         const resolver = createResolver(import.meta.url);


### PR DESCRIPTION
Right now runtimeConfig can't be a nested object, as it would overwrite the moduleOptions. With this change it applies moduleOptions over moduleDefaults and then the runtimeConfig on top of that.