### PR TITLE
feat: support new strategy based on to query parameter

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -20,6 +20,8 @@ export const moduleDefaults = {
 
     fullPathRedirect: false,
 
+    maintainQueryParamsOnRedirects: true,
+
     watchLoggedIn: true,
 
     redirect: {

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,7 +20,7 @@ export const moduleDefaults = {
 
     fullPathRedirect: false,
 
-    maintainQueryParamsOnRedirects: true,
+    redirectStrategy: 'storage',
 
     watchLoggedIn: true,
 

--- a/src/runtime/core/auth.ts
+++ b/src/runtime/core/auth.ts
@@ -370,7 +370,7 @@ export class Auth {
         if (this.options.rewriteRedirects) {
             if (['logout', 'login'].includes(name) && isRelativeURL(from) && !isSamePath(to, from)) {
                 if (this.options.redirectStrategy === 'query') {
-                    to = to + '?to=' + encodeURIComponent(queryReturnTo ? queryReturnTo : from);
+                    to = to + '?to=' + encodeURIComponent((queryReturnTo ? queryReturnTo : from) as string);
                 }
                 if (this.options.redirectStrategy === 'storage') {
                     this.$storage.setUniversal('redirect', from);
@@ -378,7 +378,7 @@ export class Auth {
             }
 
             if (name === 'home') {
-                let redirect = decodeURIComponent(activeRoute.query.to);
+                let redirect = decodeURIComponent(activeRoute.query.to as string);
 
                 if (this.options.redirectStrategy === 'storage') {
                     redirect = this.$storage.getUniversal('redirect') as string;

--- a/src/runtime/core/auth.ts
+++ b/src/runtime/core/auth.ts
@@ -392,14 +392,19 @@ export class Auth {
         if (isSamePath(to, from)) {
             return;
         }
-
         const query = activeRoute.query;
         const queryString = Object.keys(query).map((key) => key + '=' + query[key]).join('&');
 
+        let redirectTo = to;
+
+        if (this.options.maintainQueryParamsOnRedirects) {
+            redirectTo += (queryString ? '?' + queryString : '');
+        }
+
         if (!router) {
-            window.location.replace(to + (queryString ? '?' + queryString : ''));
+            window.location.replace(redirectTo);
         } else {
-            activeRouter.push(to + (queryString ? '?' + queryString : ''));
+            activeRouter.push(redirectTo);
         }
     }
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -14,6 +14,7 @@ export interface ModuleOptions {
     watchLoggedIn: boolean;
     rewriteRedirects: boolean;
     fullPathRedirect: boolean;
+    maintainQueryParamsOnRedirects: boolean;
     scopeKey: string;
     redirect: {
         login: string;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -14,7 +14,7 @@ export interface ModuleOptions {
     watchLoggedIn: boolean;
     rewriteRedirects: boolean;
     fullPathRedirect: boolean;
-    maintainQueryParamsOnRedirects: boolean;
+    redirectStrategy: string;
     scopeKey: string;
     redirect: {
         login: string;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -14,7 +14,7 @@ export interface ModuleOptions {
     watchLoggedIn: boolean;
     rewriteRedirects: boolean;
     fullPathRedirect: boolean;
-    redirectStrategy: string;
+    redirectStrategy?: string;
     scopeKey: string;
     redirect: {
         login: string;


### PR DESCRIPTION
This PR introduces an option to configure the way the redirect location is stored. Instead of storing the from location in storage (default to be a non-breaking change), it will be serialized in the query parameter `to`. The new strategy changes behavior to not append the current query parameters on redirect, as this behavior seems unintended and not particularly useful.

Redirect behavior with strategy `query`:
1. /protected-route?challenge=123
2. -> /sign-in?to=%2Fprotected-route%3Fchallenge%3Dabc
3. -> *sign-in*
4. -> redirect to /protected-route?challenge=123

Redirect behavior with strategy `storage`:
1. /protected-route?challenge=123
2. -> /sign-in?challenge=123
3. -> *sign-in*
4. -> redirect to /protected-route?challenge=123

This PR also recognizes when the redirect location is an external URL and redirects accordingly.