### PR TITLE
fix: various bugs and issues

### DIFF
--- a/src/runtime/core/auth.ts
+++ b/src/runtime/core/auth.ts
@@ -378,14 +378,16 @@ export class Auth {
             }
 
             if (name === 'home') {
-                let redirect = decodeURIComponent(activeRoute.query.to as string);
+                let redirect = activeRoute.query.to ? decodeURIComponent(activeRoute.query.to as string) : undefined;
 
                 if (this.options.redirectStrategy === 'storage') {
                     redirect = this.$storage.getUniversal('redirect') as string;
                     this.$storage.setUniversal('redirect', null);
                 }
 
-                to = redirect;
+                if (redirect) {
+                    to = redirect;
+                }
             }
         }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,16 @@ export const isUnset = (o: any): boolean => typeof o === 'undefined' || o === nu
 
 export const isSet = (o: any): boolean => !isUnset(o);
 
+export function parseQuery(queryString: string): Record<string, unknown> {
+const query = {}
+    const pairs = queryString.split('&')
+    for (let i = 0; i < pairs.length; i++) {
+        const pair = pairs[i].split('=')
+        query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '')
+    }
+    return query
+}
+
 export function isRelativeURL(u: string) {
     return (u && u.length && new RegExp(['^\\/([a-zA-Z0-9@\\-%_~.:]', '[/a-zA-Z0-9@\\-%_~.:]*)?', '([?][^#]*)?(#[^#]*)?$'].join('')).test(u));
 }


### PR DESCRIPTION
This PR fixes various issues/bugs currently present.

1. It fixes a bug with the new query redirection strategy where you would be redirected from /oauth/callback to /oauth/undefined instead of your home redirect.
2. It adds detection for composite response_types like "code id_token" in the OIDC scheme
3. It switches from parseQuery from ufo to a custom method. parseQuery can not actually parse query strings like `a=b&c=d`. This caused the fragment/hash response mode to fail every time.

@Teranode 