### PR TITLE
Prevent Overriding Existing Authorization Headers in Request Handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Teranode",

--- a/src/runtime/inc/request-handler.ts
+++ b/src/runtime/inc/request-handler.ts
@@ -93,7 +93,6 @@ export class RequestHandler {
 
     #needToken(config: FetchConfig): boolean {
         const options = this.scheme.options;
-
         const hasAuthHeader = this.#requestHasAuthorizationHeader(config)
 
         return !hasAuthHeader && (options.token!.global || Object.values(options.endpoints!).some((endpoint) => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url));

--- a/src/runtime/inc/request-handler.ts
+++ b/src/runtime/inc/request-handler.ts
@@ -94,7 +94,9 @@ export class RequestHandler {
     #needToken(config: FetchConfig): boolean {
         const options = this.scheme.options;
 
-        return (options.token!.global || Object.values(options.endpoints!).some((endpoint) => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url));
+        const hasAuthHeader = this.#requestHasAuthorizationHeader(config)
+
+        return !hasAuthHeader && (options.token!.global || Object.values(options.endpoints!).some((endpoint) => typeof endpoint === 'object' ? endpoint.url === config.url : endpoint === config.url));
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
At the moment, I have found the behaviour of the HTTP request handler to be that it overrides an existing HTTP Authorization header if there is one.

This small PR would change that behaviour so that the library user has the option to override the Authorization header on a per-request basis if they need to.