### PR TITLE
Possible fix for #30.

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,4 @@
+import { useRuntimeConfig } from '#imports'
 import { ImportOptions } from './resolve'
 import { ModuleOptions, Strategy } from './types'
 


### PR DESCRIPTION
https://github.com/nuxt-alt/auth/issues/30

The error in issue occurs only when automatic import is disabled in nuxt itself - because the module does not have direct import and it crashes. If you enable automatic import from nuxt, the useRuntimeConfig import will be resolved automatically.