### PR TITLE
fix: multiple question marks appear in a redirect URL in specific situations

### DIFF
--- a/src/runtime/core/auth.ts
+++ b/src/runtime/core/auth.ts
@@ -3,7 +3,7 @@ import type { NuxtApp } from '#app';
 import { isSet, getProp, routeMeta, isRelativeURL } from '../../utils';
 import { useRouter, useRoute } from '#imports';
 import { Storage } from './storage';
-import { isSamePath } from 'ufo'
+import { isSamePath, withQuery } from 'ufo';
 import requrl from 'requrl';
 
 export type ErrorListener = (...args: any[]) => void;
@@ -405,11 +405,9 @@ export class Auth {
         if (isSamePath(to, from)) {
             return;
         }
-        const query = activeRoute.query;
-        const queryString = Object.keys(query).map((key) => key + '=' + query[key]).join('&');
 
         if (this.options.redirectStrategy === 'storage') {
-            to += (queryString ? '?' + queryString : '');
+            to = withQuery(to, activeRoute.query);
         }
 
         if (!router || !isRelativeURL(to)) {


### PR DESCRIPTION
This small PR fixes multiple question marks appear in a redirect URL when `redirectStrategy` is `storage`.

The example below for the Oauth2 flow when `redirectStrategy` is `storage` and `rewriteRedirects`, `fullPathRedirect` are `true`:

* Version 2.3.3:
  1. `/search?q=nice_query` to `/login?q=query`
  2. External auth
  3. `/callback?code=foo&state=bar`
  4. `/search?q=query?code=foo&state=bar`
* This PR:
  1. `/search?q=query` to `/login?q=nice_query`
  2. External auth
  3. `/callback?code=foo&state=bar`
  4. `/search?q=query&code=foo&state=bar`
