### PR TITLE
Added shim for `hasOwn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "cookie-es": "latest",
         "defu": "latest",
         "jwt-decode": "latest",
+        "object.hasown": "latest",
         "ohash": "latest",
         "pathe": "latest",
         "pinia-plugin-persistedstate": "latest",

--- a/src/runtime/core/auth.ts
+++ b/src/runtime/core/auth.ts
@@ -5,6 +5,9 @@ import { navigateTo, useRoute, useRouter } from "#imports";
 import { Storage } from './storage';
 import { isSamePath, withQuery } from 'ufo';
 import requrl from 'requrl';
+import hasOwn from "object.hasown";
+
+const objectHasOwn = Object.hasOwn ?? hasOwn.shim; // adding shim in case < es2022
 
 export type ErrorListener = (...args: any[]) => void;
 export type RedirectListener = (to: string, from: string) => string;
@@ -117,7 +120,7 @@ export class Auth {
             if (process.client && this.options.watchLoggedIn) {
                 this.$storage.watchState('loggedIn', (loggedIn: boolean) => {
                     if (this.$state.loggedIn === loggedIn) return;
-                    if (Object.hasOwn(useRoute().meta, 'auth') && !routeMeta(useRoute(), 'auth', false)) {
+                    if (objectHasOwn(useRoute().meta, 'auth') && !routeMeta(useRoute(), 'auth', false)) {
                         this.redirect(loggedIn ? 'home' : 'logout');
                     }
                 });

--- a/src/runtime/core/middleware.ts
+++ b/src/runtime/core/middleware.ts
@@ -1,9 +1,12 @@
 import { routeMeta, getMatchedComponents, normalizePath } from '../../utils';
 import { useNuxtApp, defineNuxtRouteMiddleware } from '#imports';
+import hasOwn from "object.hasown";
+
+const objectHasOwn = Object.hasOwn ?? hasOwn.shim; // adding shim in case < es2022
 
 export default defineNuxtRouteMiddleware(async (to, from) => {
     // Disable middleware if options: { auth: false } is set on the route
-    if (Object.hasOwn(to.meta, 'auth') && routeMeta(to, 'auth', false)) {
+    if (objectHasOwn(to.meta, 'auth') && routeMeta(to, 'auth', false)) {
         return;
     }
 
@@ -19,7 +22,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
     const { login, callback } = ctx.$auth.options.redirect;
 
-    const pageIsInGuestMode = Object.hasOwn(to.meta, 'auth') && routeMeta(to, 'auth', 'guest');
+    const pageIsInGuestMode = objectHasOwn(to.meta, 'auth') && routeMeta(to, 'auth', 'guest');
 
     const insidePage = (page: string) => normalizePath(to.path) === normalizePath(page);
 


### PR DESCRIPTION
Firstly, thanks for this module, thanks to you guys we could actually migrate to Nuxt 3 without having to reinvent our auth :)

Opening this PR to address [this issue](https://github.com/nuxt-alt/auth/issues/47). I understand the modern browsers support it, but in our project we want to also support people with some older versions, so I added the [shim for hasOwn](https://www.npmjs.com/package/object.hasown) :)