### PR TITLE
pin jwt-decode versoin to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "body-parser": "latest",
         "cookie-es": "latest",
         "defu": "latest",
-        "jwt-decode": "latest",
+        "jwt-decode": "3.1.2",
         "ohash": "latest",
         "pathe": "latest",
         "requrl": "latest"


### PR DESCRIPTION
Hi, 

`jwt-decode` got a new release after 3yrs of inactivity: https://www.npmjs.com/package/jwt-decode?activeTab=versions
v4 breaks the module for me. It would be great if we could pin the version of jwt-decode to the latest v3 (same would be great for all dependencies, to be honest, because otherwise, surprises like these will happen constantly and without any warning, even in production when local testing was fine).