### PR TITLE
fix(temp): jwt-decode error 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "body-parser": "latest",
         "cookie-es": "latest",
         "defu": "latest",
-        "jwt-decode": "latest",
+        "jwt-decode": "<4.0.0",
         "ohash": "latest",
         "pathe": "latest",
         "requrl": "latest"


### PR DESCRIPTION
Pins the jwt-decode version to < 4.0.0 to avoid breaking the package.

This is a temporary fix only.