### PR TITLE
v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Denoder",

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,8 @@ export const moduleDefaults: ModuleOptions = {
 
     resetOnError: false,
 
+    resetOnResponseError: false,
+
     ignoreExceptions: false,
 
     // -- Authorization --

--- a/src/runtime/schemes/local.ts
+++ b/src/runtime/schemes/local.ts
@@ -65,7 +65,7 @@ export class LocalScheme<OptionsT extends LocalSchemeOptions = LocalSchemeOption
         this.token = new Token(this, this.$auth.$storage);
 
         // Initialize Request Interceptor
-        this.requestHandler = new RequestHandler(this, this.$auth.ctx.$http);
+        this.requestHandler = new RequestHandler(this, this.$auth.ctx.$http, $auth);
     }
 
     check(checkStatus = false): SchemeCheck {
@@ -151,7 +151,7 @@ export class LocalScheme<OptionsT extends LocalSchemeOptions = LocalSchemeOption
         this.updateTokens(response);
 
         // Initialize request interceptor if not initialized
-        if (!this.requestHandler.interceptor) {
+        if (!this.requestHandler.requestInterceptor) {
             this.initializeRequestInterceptor();
         }
 

--- a/src/runtime/schemes/oauth2.ts
+++ b/src/runtime/schemes/oauth2.ts
@@ -106,7 +106,7 @@ export class Oauth2Scheme<OptionsT extends Oauth2SchemeOptions = Oauth2SchemeOpt
         this.refreshController = new RefreshController(this);
 
         // Initialize Request Handler
-        this.requestHandler = new RequestHandler(this, this.$auth.ctx.$http);
+        this.requestHandler = new RequestHandler(this, this.$auth.ctx.$http, $auth);
 
         // Initialize Client Window Reference
         this.#clientWindowReference = null;

--- a/src/types/options.d.ts
+++ b/src/types/options.d.ts
@@ -1,7 +1,8 @@
 import type { Strategy } from './strategy';
 import type { NuxtPlugin } from '@nuxt/schema';
-import type { AuthState } from './index';
+import type { AuthState, RefreshableScheme, TokenableScheme } from './index';
 import type { CookieSerializeOptions } from 'cookie-es';
+import type { Auth } from '../runtime'
 
 export interface ModuleOptions {
     globalMiddleware?: boolean;
@@ -10,6 +11,7 @@ export interface ModuleOptions {
     strategies?: Record<string, Strategy>;
     ignoreExceptions: boolean;
     resetOnError: boolean | ((...args: any[]) => boolean);
+    resetOnResponseError: boolean | ((error: any, auth: Auth, scheme: TokenableScheme | RefreshableScheme) => void);
     defaultStrategy: string | undefined;
     watchLoggedIn: boolean;
     rewriteRedirects: boolean;

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,4 +1,4 @@
-import type { Oauth2SchemeOptions, RefreshSchemeOptions, LocalSchemeOptions, CookieSchemeOptions } from '../runtime';
+import type { Oauth2SchemeOptions, RefreshSchemeOptions } from '../runtime';
 import type { StrategyOptions, HTTPRequest, TokenableSchemeOptions } from '../types';
 import type { Nuxt } from '@nuxt/schema';
 import { addServerHandler, addTemplate } from '@nuxt/kit';


### PR DESCRIPTION
# **Changes & Additions**

### **Request Handler**
There are cases where you will need to handle auth errors pertaining to the request rather than the auth module itself. For instance, when utilizing the local scheme and you have a non-expiring token, and you revoke the token (in your server) (for whatever reason), the token will still be there in the store manager.

With that said a new option `resetOnResponseError` has been introduced. This can be a Boolean or a Function. Similar to `resetOnError`, but this one is for the request handler. As a function it uses 3 arguments: `error`, `auth`, and `scheme`
 it would look something like this in your Nuxt config:
 
 ```ts
 auth: {
     //... module options
     resetOnResponseError: (error, auth, scheme) => {
        if (error.response.status === 401) {
            scheme.reset?.()
            auth.redirect('login')
        }
    },
}
```

The option is disabled by default.

### **Module Options**
Functions within the module options were getting removed due to Nuxt turning them into strings thereby remove functions in the process. This will fix that issue.