### PR TITLE
v3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Denoder",

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import type { ModuleOptions } from './types';
-import { addImports, addPlugin, addPluginTemplate, addTemplate, createResolver, defineNuxtModule, installModule, addRouteMiddleware } from '@nuxt/kit';
+import { addImports, addPluginTemplate, addTemplate, createResolver, defineNuxtModule, installModule, addRouteMiddleware } from '@nuxt/kit';
 import { name, version } from '../package.json';
 import { resolveStrategies } from './resolve';
 import { moduleDefaults } from './options';

--- a/src/runtime/core/storage.ts
+++ b/src/runtime/core/storage.ts
@@ -1,7 +1,7 @@
 import type { ModuleOptions, AuthStore, AuthState, StoreMethod, StoreIncludeOptions } from '../../types';
 import type { NuxtApp } from '#app';
+import type { Pinia, StoreDefinition } from 'pinia';
 import { isUnset, isSet, decodeValue, encodeValue, setH3Cookie } from '../../utils';
-import { defineStore, type Pinia, type StoreDefinition } from 'pinia';
 import { parse, serialize, type CookieSerializeOptions } from 'cookie-es';
 import { useState } from '#imports';
 import { watch, type Ref } from 'vue';
@@ -101,12 +101,13 @@ export class Storage {
     // Local state (reactive)
     // ------------------------------------
 
-    #initState() {
+    async #initState() {
         // Use pinia for local state's if possible
         const pinia = this.ctx.$pinia as Pinia
         this.#piniaEnabled = this.options.stores.pinia!.enabled && !!pinia;
 
         if (this.#piniaEnabled) {
+            const { defineStore } = await import('pinia')
             this.#PiniaStore = defineStore(this.options.stores.pinia?.namespace!, {
                 state: (): AuthState => ({ ...this.options.initialState })
             });
@@ -154,11 +155,11 @@ export class Storage {
 
     watchState(watchKey: string, fn: (value: any) => void) {
         if (this.#piniaEnabled) {
-            watch(() => this.#initPiniaStore[watchKey as keyof AuthStore], (modified, old) => {
+            watch(() => this.#initPiniaStore?.[watchKey as keyof AuthStore], (modified, old) => {
                 fn(modified)
             }, { deep: true })
         } else {
-            watch(() => this.#initStore.value[watchKey], (modified, old) => {
+            watch(() => this.#initStore?.value?.[watchKey], (modified, old) => {
                 fn(modified)
             }, { deep: true })
         }

--- a/src/runtime/providers/google.ts
+++ b/src/runtime/providers/google.ts
@@ -10,8 +10,7 @@ export function google(nuxt: Nuxt, strategy: ProviderPartialOptions<GoogleProvid
         scheme: 'oauth2',
         endpoints: {
             authorization: 'https://accounts.google.com/o/oauth2/v2/auth',
-            userInfo: 'https://www.googleapis.com/oauth2/v3/userinfo',
-            token: 'https://oauth2.googleapis.com/token'
+            userInfo: 'https://www.googleapis.com/oauth2/v3/userinfo'
         },
         scope: ['openid', 'profile', 'email'],
     };

--- a/src/runtime/schemes/oauth2.ts
+++ b/src/runtime/schemes/oauth2.ts
@@ -29,7 +29,7 @@ export interface Oauth2SchemeOptions extends SchemeOptions, TokenableSchemeOptio
     clientSecretTransport: 'body' | 'aurthorization_header';
     scope: string | string[];
     state: string;
-    codeChallengeMethod: 'implicit' | 'S256' | 'plain' | '';
+    codeChallengeMethod: 'implicit' | 'S256' | 'plain' | '' | false;
     acrValues: string;
     audience: string;
     autoLogout: boolean;
@@ -77,7 +77,7 @@ const DEFAULTS: SchemePartialOptions<Oauth2SchemeOptions> = {
         property: false,
     },
     responseType: 'token',
-    codeChallengeMethod: 'implicit',
+    codeChallengeMethod: false,
     clientWindow: false,
     clientWindowWidth: 400,
     clientWindowHeight: 600
@@ -215,6 +215,10 @@ export class Oauth2Scheme<OptionsT extends Oauth2SchemeOptions = Oauth2SchemeOpt
             clientWindowHeight: this.options.clientWindowHeight,
             ...options.params,
         };
+
+        if (!opts.code_challenge_method) {
+            delete opts.code_challenge_method;
+        }
 
         if (this.options.organization) {
             opts.organization = this.options.organization;


### PR DESCRIPTION
# **Changes & Additions**

### **Storage**
**Fixed:** Issue where using `clearNuxtState` would make the state undefined so there would be nothing for the watcher to watch. (Issue: https://github.com/nuxt-alt/auth/issues/87)

Pinia has been moved to a dynamic module import. (discussion: https://github.com/nuxt-alt/auth/discussions/86)

### **OAuth2**
`code_challenge_method` can be set to `false` to delete the param as there were some conflicting issues with it being present when it isn't needed for whatever auth implementation that didn't utilize it.