### PR TITLE
v3.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ The default cookie storage options.
 
 The type of redirection strategy you want to use, `storage` utilizng localStorage for redirects, `query` utilizing the route query parameters.
 
+### `tokenValidationInterval`
+
+- Type: `Boolean | Number`
+- Default: `false`
+
+This is experimental. If set to true, default interval is 1000ms, otherwise set time in milliseconds. This is how often the module with attempt to validate the token for expiry.
+
 ### `resetOnResponseError`
 
 - Type: `Boolean | Function`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Denoder",

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import { addImports, addPluginTemplate, addTemplate, createResolver, defineNuxtM
 import { name, version } from '../package.json';
 import { resolveStrategies } from './resolve';
 import { moduleDefaults } from './options';
-import { getAuthDTS, getAuthPlugin } from './plugin';
+import { getAuthDTS, getAuthPlugin, converter } from './plugin';
 import { defu } from 'defu';
 
 const CONFIG_KEY = 'auth';
@@ -53,6 +53,11 @@ export default defineNuxtModule({
         // Set defaultStrategy
         options.defaultStrategy = options.defaultStrategy || strategies.length ? strategies[0].name : '';
 
+        nuxt.hook('nitro:config', (config) => {
+            config.virtual = config.virtual || {}
+            config.virtual['#nuxt-auth-options'] = `export const config = ${JSON.stringify(options, converter, 2)}`
+        })
+
         // Install http module if not in modules
         if (!nuxt.options.modules.includes('@nuxt-alt/http')) {
             installModule('@nuxt-alt/http')
@@ -91,7 +96,7 @@ export default defineNuxtModule({
 
         // Middleware
         if (options.enableMiddleware) {
-            addRouteMiddleware({ 
+            addRouteMiddleware({
                 name: 'auth',
                 path: resolver.resolve('runtime/core/middleware'),
                 global: options.globalMiddleware

--- a/src/options.ts
+++ b/src/options.ts
@@ -28,6 +28,8 @@ export const moduleDefaults: ModuleOptions = {
 
     watchLoggedIn: true,
 
+    tokenValidationInterval: false,
+
     redirect: {
         login: '/login',
         logout: '/',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -91,7 +91,7 @@ export default defineNuxtPlugin({
 })`
 }
 
-function converter(key: string, val: any) {
+export function converter(key: string, val: any) {
     if (val && val.constructor === RegExp || typeof val === 'function') {
         return String(val)
     }

--- a/src/runtime/core/storage.ts
+++ b/src/runtime/core/storage.ts
@@ -155,11 +155,11 @@ export class Storage {
 
     watchState(watchKey: string, fn: (value: any) => void) {
         if (this.#piniaEnabled) {
-            watch(() => this.#initPiniaStore?.[watchKey as keyof AuthStore], (modified, old) => {
+            watch(() => this.#initPiniaStore?.[watchKey as keyof AuthStore], (modified) => {
                 fn(modified)
             }, { deep: true })
         } else {
-            watch(() => this.#initStore?.value?.[watchKey], (modified, old) => {
+            watch(() => this.#initStore?.value?.[watchKey], (modified) => {
                 fn(modified)
             }, { deep: true })
         }

--- a/src/runtime/inc/refresh-token.ts
+++ b/src/runtime/inc/refresh-token.ts
@@ -41,7 +41,7 @@ export class RefreshToken {
     }
 
     status(): TokenStatus {
-        return new TokenStatus(this.get(), this.#getExpiration());
+        return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.refreshToken.httpOnly);
     }
 
     #getExpiration(): number | false {

--- a/src/runtime/inc/request-handler.ts
+++ b/src/runtime/inc/request-handler.ts
@@ -94,7 +94,7 @@ export class RequestHandler {
                 if (typeof this.auth.options.resetOnResponseError === 'function') {
                     this.auth.options.resetOnResponseError(error, this.auth, this.scheme)
                 }
-                else if (this.auth.options.resetOnResponseError && error.response.status === 401) {
+                else if (this.auth.options.resetOnResponseError && error?.response?.status === 401) {
                     this.scheme.reset?.()
                     throw new ExpiredAuthSessionError();
                 }

--- a/src/runtime/inc/token-status.ts
+++ b/src/runtime/inc/token-status.ts
@@ -6,9 +6,11 @@ export enum TokenStatusEnum {
 
 export class TokenStatus {
     readonly #status: TokenStatusEnum;
+    #isHttpOnly: boolean;
 
-    constructor(token: string | boolean, tokenExpiresAt: number | false) {
+    constructor(token: string | boolean, tokenExpiresAt: number | false, httpOnly: boolean = false) {
         this.#status = this.#calculate(token, tokenExpiresAt);
+        this.#isHttpOnly = httpOnly
     }
 
     unknown(): boolean {
@@ -27,7 +29,7 @@ export class TokenStatus {
         const now = Date.now();
 
         try {
-            if (!token || !tokenExpiresAt) {
+            if ((this.#isHttpOnly && !tokenExpiresAt) || (!this.#isHttpOnly && !token || !tokenExpiresAt)) {
                 return TokenStatusEnum.UNKNOWN;
             }
         } catch (error) {

--- a/src/runtime/schemes/openIDConnect.ts
+++ b/src/runtime/schemes/openIDConnect.ts
@@ -243,7 +243,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
             });
 
             token = (getProp(response._data, this.options.token!.property) as string) || token;
-            tokenExpiresIn = (getProp(response._data, 'expires_in') as number) || tokenExpiresIn
+            tokenExpiresIn = this.options.token?.maxAge || (getProp(response._data, this.options.token!.expiresProperty) as number) || 1800
             refreshToken = (getProp(response._data, this.options.refreshToken.property!) as string) || refreshToken!;
             idToken = (getProp(response._data, this.options.idToken.property) as string) || idToken;
         }

--- a/src/types/options.d.ts
+++ b/src/types/options.d.ts
@@ -14,6 +14,7 @@ export interface ModuleOptions {
     resetOnResponseError: boolean | ((error: any, auth: Auth, scheme: TokenableScheme | RefreshableScheme) => void);
     defaultStrategy: string | undefined;
     watchLoggedIn: boolean;
+    tokenValidationInterval: boolean | number;
     rewriteRedirects: boolean;
     fullPathRedirect: boolean;
     redirectStrategy?: 'query' | 'storage';

--- a/src/types/scheme.d.ts
+++ b/src/types/scheme.d.ts
@@ -50,6 +50,7 @@ export interface Scheme<OptionsT extends SchemeOptions = SchemeOptions> {
 
 export interface TokenOptions {
     property: string;
+    expiresProperty: string;
     type: string | false;
     name: string;
     maxAge: number | false;
@@ -91,6 +92,7 @@ export interface RefreshTokenOptions {
     tokenRequired: boolean;
     prefix: string;
     expirationPrefix: string;
+    httpOnly: boolean;
 }
 
 export interface RefreshableSchemeOptions extends TokenableSchemeOptions {


### PR DESCRIPTION
# **Changes & Additions**

### **OAuth2**
Introduced new feature - the `httpOnly` property is available inside of `refreshToken` for the OaAuth2 scheme. When this is enabled the refresh token if available, will be made into an httpOnly cookie. By default this is disabled as it is experimental.

This option is not available for the `access_token` for the time being, due to the complexity of the module.

### **Module Options**
`tokenValidationInterval` - `boolean | number` - When set to true, the default interval is 1000ms otherwise you can set the interval manually in ms. This will periodically validate the `access_token` to check if it's expired, this is similar to the `resestOnError/resetOnResponseError` options, but this is done in an interval.