### PR TITLE
v3.1.0 - Refactor: HttpOnly cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "3.0.5",
+    "version": "3.1.0",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Denoder",

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import type { ModuleOptions } from './types';
-import { addImports, addPluginTemplate, addTemplate, createResolver, defineNuxtModule, installModule, addRouteMiddleware } from '@nuxt/kit';
+import { addImports, addPluginTemplate, addTemplate, createResolver, defineNuxtModule, installModule, addRouteMiddleware, addServerHandler } from '@nuxt/kit';
 import { name, version } from '../package.json';
 import { resolveStrategies } from './resolve';
 import { moduleDefaults } from './options';
@@ -93,6 +93,14 @@ export default defineNuxtModule({
 
         // Transpile
         nuxt.options.build.transpile.push(runtime, providers, utils)
+
+        if (nuxt.options.ssr) {
+            addServerHandler({
+                route: '/_auth/reset',
+                method: 'post',
+                handler: resolver.resolve(runtime, 'token-nitro'),
+            })
+        }
 
         // Middleware
         if (options.enableMiddleware) {

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,5 +1,6 @@
 import type { Strategy, ModuleOptions, ProviderNames, SchemeNames } from './types';
 import type { Nuxt } from '@nuxt/schema';
+import { addAuthorize, addLocalAuthorize, assignAbsoluteEndpoints, assignDefaults } from './utils/provider';
 import { ProviderAliases } from './runtime/providers';
 import * as AUTH_PROVIDERS from './runtime/providers';
 import { resolvePath } from '@nuxt/kit';
@@ -14,6 +15,113 @@ export const BuiltinSchemes = {
     refresh: 'RefreshScheme',
     laravelJWT: 'LaravelJWTScheme',
     auth0: 'Auth0Scheme',
+};
+
+export const OAUTH2DEFAULTS = {
+    accessType: undefined,
+    redirectUri: undefined,
+    logoutRedirectUri: undefined,
+    clientId: undefined,
+    clientSecretTransport: 'body',
+    audience: undefined,
+    grantType: undefined,
+    responseMode: undefined,
+    acrValues: undefined,
+    autoLogout: false,
+    endpoints: {
+        logout: undefined,
+        authorization: undefined,
+        token: undefined,
+        userInfo: undefined,
+    },
+    scope: [],
+    token: {
+        property: 'access_token',
+        expiresProperty: 'expires_in',
+        type: 'Bearer',
+        name: 'Authorization',
+        maxAge: false,
+        global: true,
+        prefix: '_token.',
+        expirationPrefix: '_token_expiration.',
+    },
+    idToken: {
+        property: 'id_token',
+        maxAge: 1800,
+        prefix: '_id_token.',
+        expirationPrefix: '_id_token_expiration.',
+    },
+    refreshToken: {
+        property: 'refresh_token',
+        maxAge: 60 * 60 * 24 * 30,
+        prefix: '_refresh_token.',
+        expirationPrefix: '_refresh_token_expiration.',
+        httpOnly: false,
+    },
+    user: {
+        property: false,
+    },
+    responseType: 'token',
+    codeChallengeMethod: false,
+    clientWindow: false,
+    clientWindowWidth: 400,
+    clientWindowHeight: 600
+};
+
+export const LOCALDEFAULTS = {
+    cookie: {
+        name: undefined
+    },
+    endpoints: {
+        csrf: {
+            url: '/api/csrf-cookie',
+        },
+        login: {
+            url: '/api/auth/login',
+            method: 'post',
+        },
+        logout: {
+            url: '/api/auth/logout',
+            method: 'post',
+        },
+        user: {
+            url: '/api/auth/user',
+            method: 'get',
+        },
+        refresh: {
+            url: '/api/auth/refresh',
+            method: 'POST',
+        },
+    },
+    token: {
+        expiresProperty: 'expires_in',
+        property: 'token',
+        type: 'Bearer',
+        name: 'Authorization',
+        maxAge: false,
+        global: true,
+        required: true,
+        prefix: '_token.',
+        expirationPrefix: '_token_expiration.',
+    },
+    refreshToken: {
+        property: 'refresh_token',
+        data: 'refresh_token',
+        maxAge: 60 * 60 * 24 * 30,
+        required: true,
+        tokenRequired: false,
+        prefix: '_refresh_token.',
+        expirationPrefix: '_refresh_token_expiration.',
+        httpOnly: false,
+    },
+    autoLogout: false,
+    user: {
+        property: 'user',
+        autoFetch: true,
+    },
+    clientId: false,
+    grantType: false,
+    scope: false,
 };
 
 export interface ImportOptions {
@@ -44,13 +152,15 @@ export async function resolveStrategies(nuxt: Nuxt, options: ModuleOptions) {
             strategy.provider = strategy.name as ProviderNames;
         }
 
+        // Determine if SSR is enabled
+        strategy.ssr = nuxt.options.ssr
+
         // Try to resolve provider
-        const provider = await resolveProvider(strategy.provider);
+        const provider = await resolveProvider(strategy.provider, nuxt, strategy);
 
         delete strategy.provider;
 
-        // check that the provider isn't a nuxt module
-        if (typeof provider === 'function') {
+        if (typeof provider === "function") {
             provider(nuxt, strategy);
         }
 
@@ -103,7 +213,7 @@ export async function resolveScheme(scheme: string) {
     }
 }
 
-export async function resolveProvider(provider: string | ((...args: any[]) => any)) {
+export async function resolveProvider(provider: string | ((...args: any[]) => any), nuxt: Nuxt, strategy: Strategy) {
 
     provider = (ProviderAliases[provider as keyof typeof ProviderAliases] || provider);
 
@@ -113,11 +223,26 @@ export async function resolveProvider(provider: string | ((...args: any[]) => an
 
     // return the provider
     if (typeof provider === 'function') {
-        return provider;
+        return provider(nuxt, strategy);
     }
 
     // return an empty function as it doesn't use a provider
     if (typeof provider === 'string') {
-        return (nuxt, strategy) => {}
+        return (nuxt: Nuxt, strategy: Strategy) => {
+            if (['oauth2', 'openIDConnect', 'auth0'].includes(strategy.scheme!) && strategy.ssr) {
+                assignDefaults(strategy as any, OAUTH2DEFAULTS)
+                addAuthorize(nuxt, strategy as any, true)
+            }
+
+            if (['refresh', 'local', 'cookie'].includes(strategy.scheme!) && strategy.ssr) {
+                assignDefaults(strategy as any, LOCALDEFAULTS)
+
+                if (strategy.url) {
+                    assignAbsoluteEndpoints(strategy as any);
+                }
+
+                addLocalAuthorize(nuxt, strategy as any)
+            }
+        }
     }
 }

--- a/src/runtime/core/storage.ts
+++ b/src/runtime/core/storage.ts
@@ -13,14 +13,13 @@ export class Storage {
     #initPiniaStore!: AuthStore;
     #initStore!: Ref<AuthState>;
     state: AuthState;
-    #state: AuthState;
+    memory!: Ref<AuthState>;
     #piniaEnabled: boolean = false;
 
     constructor(ctx: NuxtApp, options: ModuleOptions) {
         this.ctx = ctx;
         this.options = options;
         this.state = options.initialState!
-        this.#state = options.initialState!
 
         this.#initState();
     }
@@ -104,7 +103,7 @@ export class Storage {
     async #initState() {
         // Use pinia for local state's if possible
         const pinia = this.ctx.$pinia as Pinia
-        this.#piniaEnabled = this.options.stores.pinia!.enabled && !!pinia;
+        this.#piniaEnabled = this.options.stores.pinia!?.enabled! && !!pinia;
 
         if (this.#piniaEnabled) {
             const { defineStore } = await import('pinia')
@@ -121,6 +120,8 @@ export class Storage {
 
             this.state = this.#initStore.value
         }
+
+        this.memory = useState<AuthState>('auth-internal', () => ({}))
     }
 
     get pinia() {
@@ -133,7 +134,7 @@ export class Storage {
 
     setState(key: string, value: any) {
         if (key.startsWith('_')) {
-            this.#state[key] = value;
+            this.memory.value[key] = value;
         }
         else if (this.#piniaEnabled) {
             this.#initPiniaStore.$patch({ [key]: value });
@@ -149,7 +150,7 @@ export class Storage {
         if (!key.startsWith('_')) {
             return this.state[key];
         } else {
-            return this.#state[key];
+            return this.memory.value[key];
         }
     }
 

--- a/src/runtime/inc/refresh-token.ts
+++ b/src/runtime/inc/refresh-token.ts
@@ -36,12 +36,20 @@ export class RefreshToken {
     }
 
     reset(): void {
+        this.#resetSSRToken()
         this.#setToken(false);
         this.#setExpiration(false);
     }
 
     status(): TokenStatus {
         return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.refreshToken.httpOnly);
+    }
+
+    #resetSSRToken() {
+        if (this.scheme.options.ssr && this.scheme.options.refreshToken?.httpOnly) {
+            const key = this.scheme.options.refreshToken!.prefix + this.scheme.name;
+            this.scheme.$auth.request({ baseURL: '', url: '/_auth/reset', body: new URLSearchParams({ token: key }), method: 'POST' })
+        }
     }
 
     #getExpiration(): number | false {

--- a/src/runtime/inc/refresh-token.ts
+++ b/src/runtime/inc/refresh-token.ts
@@ -19,7 +19,7 @@ export class RefreshToken {
         return this.$storage.getUniversal(key) as string | boolean;
     }
 
-    set(tokenValue: string | boolean): string | boolean {
+    set(tokenValue: string | boolean): string | boolean | void | null | undefined {
         const refreshToken = addTokenPrefix(tokenValue, this.scheme.options.refreshToken.type);
 
         this.#setToken(refreshToken);
@@ -28,7 +28,7 @@ export class RefreshToken {
         return refreshToken;
     }
 
-    sync(): string | boolean {
+    sync(): string | boolean | void | null | undefined {
         const refreshToken = this.#syncToken();
         this.#syncExpiration();
 
@@ -37,15 +37,15 @@ export class RefreshToken {
 
     reset(): void {
         this.#resetSSRToken()
-        this.#setToken(false);
-        this.#setExpiration(false);
+        this.#setToken(undefined);
+        this.#setExpiration(undefined);
     }
 
     status(): TokenStatus {
         return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.refreshToken.httpOnly);
     }
 
-    #resetSSRToken() {
+    #resetSSRToken(): void {
         if (this.scheme.options.ssr && this.scheme.options.refreshToken?.httpOnly) {
             const key = this.scheme.options.refreshToken!.prefix + this.scheme.name;
             this.scheme.$auth.request({ baseURL: '', url: '/_auth/reset', body: new URLSearchParams({ token: key }), method: 'POST' })
@@ -58,19 +58,19 @@ export class RefreshToken {
         return this.$storage.getUniversal(key) as number | false;
     }
 
-    #setExpiration(expiration: number | false): number | false {
+    #setExpiration(expiration: number | false | undefined | null): number | false | void | null | undefined {
         const key = this.scheme.options.refreshToken.expirationPrefix + this.scheme.name;
 
-        return this.$storage.setUniversal(key, expiration) as number | false;
+        return this.$storage.setUniversal(key, expiration);
     }
 
     #syncExpiration(): number | false {
         const key = this.scheme.options.refreshToken.expirationPrefix + this.scheme.name;
 
-        return this.$storage.syncUniversal(key) as number | false;
+        return this.$storage.syncUniversal(key);
     }
 
-    #updateExpiration(refreshToken: string | boolean): number | false | void {
+    #updateExpiration(refreshToken: string | boolean): number | false | void | null | undefined {
         let refreshTokenExpiration: number;
         const tokenIssuedAtMillis = Date.now();
         const tokenTTLMillis = Number(this.scheme.options.refreshToken.maxAge) * 1000;
@@ -91,13 +91,13 @@ export class RefreshToken {
         return this.#setExpiration(refreshTokenExpiration || false);
     }
 
-    #setToken(refreshToken: string | boolean): string | boolean {
+    #setToken(refreshToken: string | boolean | undefined | null): string | boolean | void | null | undefined {
         const key = this.scheme.options.refreshToken.prefix + this.scheme.name;
 
-        return this.$storage.setUniversal(key, refreshToken) as string | boolean;
+        return this.$storage.setUniversal(key, refreshToken);
     }
 
-    #syncToken(): string | boolean {
+    #syncToken(): string | boolean | void | null | undefined {
         const key = this.scheme.options.refreshToken.prefix + this.scheme.name;
 
         return this.$storage.syncUniversal(key) as string | boolean;

--- a/src/runtime/inc/token.ts
+++ b/src/runtime/inc/token.ts
@@ -46,12 +46,20 @@ export class Token {
 
     reset(): void {
         this.scheme.requestHandler!.clearHeader();
+        this.#resetSSRToken();
         this.#setToken(false);
         this.#setExpiration(false);
     }
 
     status(): TokenStatus {
-        return new TokenStatus(this.get(), this.#getExpiration());
+        return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.token?.httpOnly);
+    }
+
+    #resetSSRToken() {
+        if (this.scheme.options.ssr && this.scheme.options.token?.httpOnly) {
+            const key = this.scheme.options.token!.prefix + this.scheme.name;
+            this.scheme.$auth.request({ baseURL: '', url: '/_auth/reset', body: new URLSearchParams({ token: key }), method: 'POST' })
+        }
     }
 
     #getExpiration(): number | false {

--- a/src/runtime/inc/token.ts
+++ b/src/runtime/inc/token.ts
@@ -20,7 +20,7 @@ export class Token {
         return this.$storage.getUniversal(key) as string | boolean;
     }
 
-    set(tokenValue: string | boolean, expiresIn: number | boolean = false): string | boolean {
+    set(tokenValue: string | boolean, expiresIn: number | boolean = false): string | boolean | void | null | undefined {
         const token = addTokenPrefix(tokenValue, this.scheme.options.token!.type);
 
         this.#setToken(token);
@@ -33,7 +33,7 @@ export class Token {
         return token;
     }
 
-    sync(): string | boolean {
+    sync(): string | boolean | void | null | undefined {
         const token = this.#syncToken();
         this.#syncExpiration();
 
@@ -47,15 +47,15 @@ export class Token {
     reset(): void {
         this.scheme.requestHandler!.clearHeader();
         this.#resetSSRToken();
-        this.#setToken(false);
-        this.#setExpiration(false);
+        this.#setToken(undefined);
+        this.#setExpiration(undefined);
     }
 
     status(): TokenStatus {
         return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.token?.httpOnly);
     }
 
-    #resetSSRToken() {
+    #resetSSRToken(): void {
         if (this.scheme.options.ssr && this.scheme.options.token?.httpOnly) {
             const key = this.scheme.options.token!.prefix + this.scheme.name;
             this.scheme.$auth.request({ baseURL: '', url: '/_auth/reset', body: new URLSearchParams({ token: key }), method: 'POST' })
@@ -68,19 +68,19 @@ export class Token {
         return this.$storage.getUniversal(key) as number | false;
     }
 
-    #setExpiration(expiration: number | false): number | false {
+    #setExpiration(expiration: number | false | undefined | null): number | false | void | null | undefined {
         const key = this.scheme.options.token!.expirationPrefix + this.scheme.name;
 
-        return this.$storage.setUniversal(key, expiration) as number | false;
+        return this.$storage.setUniversal(key, expiration);
     }
 
     #syncExpiration(): number | false {
         const key = this.scheme.options.token!.expirationPrefix + this.scheme.name;
 
-        return this.$storage.syncUniversal(key) as number | false;
+        return this.$storage.syncUniversal(key);
     }
 
-    #updateExpiration(token: string | boolean, expiresIn: number | boolean): number | false | void {
+    #updateExpiration(token: string | boolean, expiresIn: number | boolean): number | false | void | null | undefined {
         let tokenExpiration: number;
         const tokenIssuedAtMillis = Date.now();
         const maxAge = expiresIn ? expiresIn : this.scheme.options.token!.maxAge
@@ -103,15 +103,15 @@ export class Token {
         return this.#setExpiration(tokenExpiration || false);
     }
 
-    #setToken(token: string | boolean): string | boolean {
+    #setToken(token: string | boolean | undefined | null): string | boolean | void | null | undefined {
         const key = this.scheme.options.token!.prefix + this.scheme.name;
 
-        return this.$storage.setUniversal(key, token) as string | boolean;
+        return this.$storage.setUniversal(key, token);
     }
 
-    #syncToken(): string | boolean {
+    #syncToken(): string | boolean | void | null | undefined {
         const key = this.scheme.options.token!.prefix + this.scheme.name;
 
-        return this.$storage.syncUniversal(key) as string | boolean;
+        return this.$storage.syncUniversal(key)
     }
 }

--- a/src/runtime/providers/auth0.ts
+++ b/src/runtime/providers/auth0.ts
@@ -2,13 +2,14 @@ import type { ProviderOptions, ProviderPartialOptions } from '../../types';
 import type { Oauth2SchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
 import { assignDefaults } from '../../utils/provider';
+import { OAUTH2DEFAULTS } from '../../resolve';
 
 export interface Auth0ProviderOptions extends ProviderOptions, Oauth2SchemeOptions {
     domain: string;
 }
 
 export function auth0(nuxt: Nuxt, strategy: ProviderPartialOptions<Auth0ProviderOptions>): void {
-    const DEFAULTS: typeof strategy = {
+    const DEFAULTS = Object.assign(OAUTH2DEFAULTS, {
         scheme: 'auth0',
         endpoints: {
             authorization: `https://${strategy.domain}/authorize`,
@@ -17,7 +18,7 @@ export function auth0(nuxt: Nuxt, strategy: ProviderPartialOptions<Auth0Provider
             logout: `https://${strategy.domain}/v2/logout`,
         },
         scope: ['openid', 'profile', 'email'],
-    };
+    })
 
-    assignDefaults(strategy, DEFAULTS);
+    assignDefaults(strategy, DEFAULTS as typeof strategy);
 }

--- a/src/runtime/providers/discord.ts
+++ b/src/runtime/providers/discord.ts
@@ -2,11 +2,12 @@ import type { ProviderOptions, ProviderPartialOptions } from '../../types';
 import type { Oauth2SchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
 import { assignDefaults, addAuthorize } from '../../utils/provider';
+import { OAUTH2DEFAULTS } from '../../resolve';
 
 export interface DiscordProviderOptions extends ProviderOptions, Oauth2SchemeOptions {}
 
 export function discord(nuxt: Nuxt, strategy: ProviderPartialOptions<DiscordProviderOptions>): void {
-    const DEFAULTS: typeof strategy = {
+    const DEFAULTS = Object.assign(OAUTH2DEFAULTS, {
         scheme: 'oauth2',
         endpoints: {
             authorization: 'https://discord.com/api/oauth2/authorize',
@@ -17,9 +18,9 @@ export function discord(nuxt: Nuxt, strategy: ProviderPartialOptions<DiscordProv
         grantType: 'authorization_code',
         codeChallengeMethod: 'S256',
         scope: ['identify', 'email'],
-    };
+    })
 
-    assignDefaults(strategy, DEFAULTS);
+    assignDefaults(strategy, DEFAULTS as typeof strategy);
 
     addAuthorize(nuxt, strategy, true);
 }

--- a/src/runtime/providers/facebook.ts
+++ b/src/runtime/providers/facebook.ts
@@ -2,18 +2,19 @@ import type { ProviderPartialOptions, ProviderOptions } from '../../types';
 import type { Oauth2SchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
 import { assignDefaults } from '../../utils/provider';
+import { OAUTH2DEFAULTS } from '../../resolve';
 
 export interface FacebookProviderOptions extends ProviderOptions, Oauth2SchemeOptions {}
 
 export function facebook(nuxt: Nuxt, strategy: ProviderPartialOptions<FacebookProviderOptions>): void {
-    const DEFAULTS: typeof strategy = {
+    const DEFAULTS = Object.assign(OAUTH2DEFAULTS, {
         scheme: 'oauth2',
         endpoints: {
             authorization: 'https://facebook.com/v2.12/dialog/oauth',
             userInfo: 'https://graph.facebook.com/v2.12/me?fields=about,name,picture{url},email',
         },
         scope: ['public_profile', 'email'],
-    };
+    })
 
-    assignDefaults(strategy, DEFAULTS);
+    assignDefaults(strategy, DEFAULTS as typeof strategy);
 }

--- a/src/runtime/providers/github.ts
+++ b/src/runtime/providers/github.ts
@@ -2,11 +2,12 @@ import type { ProviderOptions, ProviderPartialOptions } from '../../types';
 import type { Oauth2SchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
 import { assignDefaults, addAuthorize } from '../../utils/provider';
+import { OAUTH2DEFAULTS } from '../../resolve';
 
 export interface GithubProviderOptions extends ProviderOptions, Oauth2SchemeOptions {}
 
 export function github(nuxt: Nuxt, strategy: ProviderPartialOptions<GithubProviderOptions>): void {
-    const DEFAULTS: typeof strategy = {
+    const DEFAULTS = Object.assign(OAUTH2DEFAULTS, {
         scheme: 'oauth2',
         endpoints: {
             authorization: 'https://github.com/login/oauth/authorize',
@@ -14,9 +15,9 @@ export function github(nuxt: Nuxt, strategy: ProviderPartialOptions<GithubProvid
             userInfo: 'https://api.github.com/user',
         },
         scope: ['user', 'email'],
-    };
+    })
 
-    assignDefaults(strategy, DEFAULTS);
+    assignDefaults(strategy, DEFAULTS as typeof strategy);
 
     addAuthorize(nuxt, strategy);
 }

--- a/src/runtime/providers/google.ts
+++ b/src/runtime/providers/google.ts
@@ -2,18 +2,19 @@ import type { ProviderPartialOptions, ProviderOptions } from '../../types';
 import type { Oauth2SchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
 import { assignDefaults } from '../../utils/provider';
+import { OAUTH2DEFAULTS } from '../../resolve';
 
 export interface GoogleProviderOptions extends ProviderOptions, Oauth2SchemeOptions {}
 
 export function google(nuxt: Nuxt, strategy: ProviderPartialOptions<GoogleProviderOptions>): void {
-    const DEFAULTS: typeof strategy = {
+    const DEFAULTS = Object.assign(OAUTH2DEFAULTS, {
         scheme: 'oauth2',
         endpoints: {
             authorization: 'https://accounts.google.com/o/oauth2/v2/auth',
             userInfo: 'https://www.googleapis.com/oauth2/v3/userinfo'
         },
         scope: ['openid', 'profile', 'email'],
-    };
+    })
 
-    assignDefaults(strategy, DEFAULTS);
+    assignDefaults(strategy, DEFAULTS as typeof strategy);
 }

--- a/src/runtime/providers/laravel-jwt.ts
+++ b/src/runtime/providers/laravel-jwt.ts
@@ -2,6 +2,7 @@ import type { ProviderPartialOptions, ProviderOptions } from '../../types';
 import type { RefreshSchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
 import { assignDefaults, assignAbsoluteEndpoints } from '../../utils/provider';
+import { LOCALDEFAULTS } from '../../resolve';
 
 export interface LaravelJWTProviderOptions extends ProviderOptions, RefreshSchemeOptions {
     url: string;
@@ -14,7 +15,7 @@ export function laravelJWT(nuxt: Nuxt, strategy: ProviderPartialOptions<LaravelJ
         throw new Error('url is required for laravel jwt!');
     }
 
-    const DEFAULTS: typeof strategy = {
+    const DEFAULTS = Object.assign(LOCALDEFAULTS, {
         name: 'laravelJWT',
         scheme: 'laravelJWT',
         endpoints: {
@@ -47,9 +48,9 @@ export function laravelJWT(nuxt: Nuxt, strategy: ProviderPartialOptions<LaravelJ
         },
         clientId: false,
         grantType: false,
-    };
+    })
 
-    assignDefaults(strategy, DEFAULTS);
+    assignDefaults(strategy, DEFAULTS as typeof strategy);
 
     assignAbsoluteEndpoints(strategy);
 }

--- a/src/runtime/providers/laravel-passport.ts
+++ b/src/runtime/providers/laravel-passport.ts
@@ -2,6 +2,7 @@ import type { RefreshTokenOptions, TokenOptions, UserOptions, RecursivePartial, 
 import type { Oauth2SchemeOptions, RefreshSchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
 import { assignDefaults, addAuthorize, initializePasswordGrantFlow, assignAbsoluteEndpoints } from '../../utils/provider';
+import { LOCALDEFAULTS } from '../../resolve';
 
 export interface LaravelPassportProviderOptions extends ProviderOptions, Oauth2SchemeOptions {
     url: string;
@@ -30,7 +31,7 @@ export function laravelPassport(nuxt: Nuxt, strategy: PartialPassportOptions | P
         token: TokenOptions;
         refreshToken: RefreshTokenOptions;
         user: UserOptions;
-    }> = {
+    }> = Object.assign(LOCALDEFAULTS, {
         name: 'laravelPassport',
         token: {
             property: 'access_token',
@@ -46,7 +47,7 @@ export function laravelPassport(nuxt: Nuxt, strategy: PartialPassportOptions | P
         user: {
             property: false,
         },
-    };
+    })
 
     let DEFAULTS: typeof strategy
 

--- a/src/runtime/providers/laravel-sanctum.ts
+++ b/src/runtime/providers/laravel-sanctum.ts
@@ -1,7 +1,8 @@
 import type { ProviderPartialOptions, HTTPRequest, ProviderOptions } from '../../types';
 import type { CookieSchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
-import { assignAbsoluteEndpoints, assignDefaults } from '../../utils/provider';
+import { assignAbsoluteEndpoints, assignDefaults, addLocalAuthorize } from '../../utils/provider';
+import { LOCALDEFAULTS } from '../../resolve';
 
 export interface LaravelSanctumProviderOptions extends ProviderOptions, CookieSchemeOptions {}
 
@@ -10,7 +11,7 @@ export function laravelSanctum(nuxt: Nuxt, strategy: ProviderPartialOptions<Lara
         credentials: 'include'
     };
 
-    const DEFAULTS: typeof strategy = {
+    const DEFAULTS = Object.assign(LOCALDEFAULTS, {
         scheme: 'cookie',
         name: 'laravelSanctum',
         cookie: {
@@ -24,6 +25,10 @@ export function laravelSanctum(nuxt: Nuxt, strategy: ProviderPartialOptions<Lara
             login: {
                 ...endpointDefaults,
                 url: '/login',
+            },
+            refresh: {
+                ...endpointDefaults,
+                url: '/refresh'
             },
             logout: {
                 ...endpointDefaults,
@@ -41,11 +46,16 @@ export function laravelSanctum(nuxt: Nuxt, strategy: ProviderPartialOptions<Lara
         token: {
             type: 'Bearer',
         }
-    };
+    })
 
-    assignDefaults(strategy, DEFAULTS)
+    assignDefaults(strategy, DEFAULTS as typeof strategy)
 
     if (strategy.url) {
         assignAbsoluteEndpoints(strategy)
     }
+
+    if (strategy.scheme === 'refresh') {
+        addLocalAuthorize(nuxt, strategy);
+    }
+
 }

--- a/src/runtime/schemes/cookie.ts
+++ b/src/runtime/schemes/cookie.ts
@@ -99,6 +99,11 @@ export class CookieScheme<OptionsT extends CookieSchemeOptions> extends LocalSch
             return;
         }
 
+        // @ts-ignore
+        if (this.options.ssr) {
+            endpoint.baseURL = ''
+        }
+
         // Make login request
         const response = await this.$auth.request(endpoint, this.options.endpoints.login);
 

--- a/src/runtime/schemes/laravel-jwt.ts
+++ b/src/runtime/schemes/laravel-jwt.ts
@@ -2,7 +2,7 @@ import type { HTTPResponse } from '../../types';
 import { RefreshScheme } from './refresh';
 
 export class LaravelJWTScheme extends RefreshScheme {
-    protected updateTokens(response: HTTPResponse<any>, { isRefreshing = false, updateOnRefresh = false } = {}): void {
-        super.updateTokens(response, { isRefreshing, updateOnRefresh });
+    protected updateTokens(response: HTTPResponse<any>): void {
+        super.updateTokens(response);
     }
 }

--- a/src/runtime/schemes/oauth2.ts
+++ b/src/runtime/schemes/oauth2.ts
@@ -108,7 +108,7 @@ export class Oauth2Scheme<OptionsT extends Oauth2SchemeOptions = Oauth2SchemeOpt
         this.refreshController = new RefreshController(this);
 
         // Initialize Request Handler
-        this.requestHandler = new RequestHandler(this, this.$auth.ctx.$http, $auth);
+        this.requestHandler = new RequestHandler(this, process.server ? this.$auth.ctx.ssrContext!.event.$http : this.$auth.ctx.$http, $auth);
 
         // Initialize Client Window Reference
         this.#clientWindowReference = null;

--- a/src/runtime/token-nitro.ts
+++ b/src/runtime/token-nitro.ts
@@ -1,0 +1,11 @@
+import { readBody, defineEventHandler, deleteCookie } from 'h3'
+import { config } from '#nuxt-auth-options'
+
+export default defineEventHandler(async (event) => {
+    const body = await readBody(event)
+    const token = config.stores?.cookie?.prefix + body?.token
+
+    if (token) {
+        deleteCookie(event, token, { ...config.stores.cookie.options })
+    }
+})

--- a/src/types/options.d.ts
+++ b/src/types/options.d.ts
@@ -24,11 +24,11 @@ export interface ModuleOptions {
             namespace?: string
         };
         pinia: {
-            enabled: boolean;
+            enabled?: boolean;
             namespace?: string;
         };
         cookie: {
-            enabled: boolean;
+            enabled?: boolean;
             prefix?: string;
             options?: CookieSerializeOptions;
         };
@@ -37,7 +37,7 @@ export interface ModuleOptions {
             prefix?: string; 
         };
         session: { 
-            enabled: boolean;
+            enabled?: boolean;
             prefix?: string;
         };
     }>,

--- a/src/types/scheme.d.ts
+++ b/src/types/scheme.d.ts
@@ -18,6 +18,7 @@ export interface EndpointsOption {
 
 export interface SchemeOptions {
     name?: string;
+    ssr?: boolean;
 }
 
 export type SchemePartialOptions<Options extends SchemeOptions> = PartialExcept<Options, keyof SchemeOptions>;
@@ -58,6 +59,7 @@ export interface TokenOptions {
     required: boolean;
     prefix: string;
     expirationPrefix: string;
+    httpOnly: boolean
 }
 
 export interface TokenableSchemeOptions extends SchemeOptions {

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -30,6 +30,7 @@ export function addAuthorize<SOptions extends StrategyOptions<Oauth2SchemeOption
         filename: `authorize-${strategy.name}.ts`,
         write: true,
         getContents: () => authorizeGrant({
+            baseURL: nuxt.options.http?.baseURL,
             strategy,
             useForms,
             clientSecret,
@@ -296,6 +297,10 @@ export default defineEventHandler(async (event) => {
         serverURL = 'http://[' + host + ']:' + port;
     } else {
         serverURL = 'http://' + host + ':' + port;
+    }
+
+    if (!host) {
+        serverURL = options.baseURL
     }
 
     const response = await event.$http.post(authorizationURL, {

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -30,7 +30,6 @@ export function addAuthorize<SOptions extends StrategyOptions<Oauth2SchemeOption
         filename: `authorize-${strategy.name}.ts`,
         write: true,
         getContents: () => authorizeGrant({
-            endpoint,
             strategy,
             useForms,
             clientSecret,
@@ -44,6 +43,31 @@ export function addAuthorize<SOptions extends StrategyOptions<Oauth2SchemeOption
         route: endpoint,
         method: 'post',
         handler: join(nuxt.options.buildDir, `authorize-${strategy.name}.ts`),
+    })
+}
+
+export function addLocalAuthorize<SOptions extends StrategyOptions<RefreshSchemeOptions>>(nuxt: Nuxt, strategy: SOptions): void {
+    const tokenEndpoint = strategy.endpoints?.login?.url;
+    const refreshEndpoint = strategy.endpoints?.refresh?.url;
+    // Endpoint
+    const endpoint = `/_auth/local/${strategy.name}/authorize`;
+    strategy.endpoints!.login!.url = endpoint;
+    strategy.endpoints!.refresh!.url = endpoint;
+
+    addTemplate({
+        filename: `local-${strategy.name}.ts`,
+        write: true,
+        getContents: () => localAuthorizeGrant({
+            strategy,
+            tokenEndpoint,
+            refreshEndpoint
+        }),
+    })
+
+    addServerHandler({
+        route: endpoint,
+        method: 'post',
+        handler: join(nuxt.options.buildDir, `local-${strategy.name}.ts`),
     })
 }
 
@@ -65,7 +89,6 @@ export function initializePasswordGrantFlow<SOptions extends StrategyOptions<Ref
         filename: `password-${strategy.name}.ts`,
         write: true,
         getContents: () => passwordGrant({
-            endpoint,
             strategy,
             clientSecret,
             clientId,
@@ -106,10 +129,18 @@ export function assignAbsoluteEndpoints<SOptions extends StrategyOptions<(Tokena
 
 export function authorizeGrant(opt: any): string {
 return `import { defineEventHandler, readBody, createError, getCookie } from 'h3'
-import { createInstance } from '@refactorjs/ofetch'
 import { config } from '#nuxt-auth-options'
+import { serialize } from 'cookie-es'
 
-const options = ${JSON.stringify(opt)}
+const options = ${JSON.stringify(opt, null, 4)}
+
+function addTokenPrefix(token: string | boolean, tokenType: string | false): string | boolean {
+    if (!token || !tokenType || typeof token !== 'string' || token.startsWith(tokenType)) {
+        return token;
+    }
+
+    return tokenType + ' ' + token;
+}
 
 export default defineEventHandler(async (event) => {
     const {
@@ -121,8 +152,9 @@ export default defineEventHandler(async (event) => {
         refresh_token: refreshToken
     } = await readBody(event)
 
-    const cookieName = config.stores.cookie.prefix + (options.strategy?.refreshToken?.prefix || '_refresh_token.') + options.strategy.name
-    const serverRefreshToken = getCookie(event, cookieName)
+    const refreshCookieName = config.stores.cookie.prefix + options.strategy?.refreshToken?.prefix + options.strategy.name
+    const tokenCookieName = config.stores.cookie.prefix + options.strategy?.token?.prefix + options.strategy.name
+    const serverRefreshToken = getCookie(event, refreshCookieName)
 
     // Grant type is authorization code, but code is not available
     if (grantType === 'authorization_code' && !code) {
@@ -173,40 +205,124 @@ export default defineEventHandler(async (event) => {
         headers['Content-Type'] = 'application/x-www-form-urlencoded'
     }
 
-    const $fetch = createInstance()
-
-    await $fetch.post(options.tokenEndpoint, {
-        body: body,
+    const response = await event.$http.post(options.tokenEndpoint, {
+        body,
         headers
     })
-    .then((response) => {
-        if (config.stores.cookie.enabled) {
-            const cookieValue = response._data[options.strategy?.refreshToken?.property || 'refresh_token']
 
-            // Create the cookie options string
-            // setCookie() doesnt work here for some reason
-            let cookieOptions = Object.keys({ ...config.stores.cookie.options, httpOnly: true }).reduce((accumulated, currentOptionKey) => {
-                if (currentOptionKey === 'maxAge') {
-                    return \`\${accumulated}; Max-Age=\${config.stores.cookie.options[currentOptionKey]}\`;
-                }
-                if (config.stores.cookie.options[currentOptionKey] === true) {
-                    return \`\${accumulated}; \${currentOptionKey.charAt(0).toUpperCase() + currentOptionKey.slice(1)}\`;
-                }
-                return \`\${accumulated}; \${currentOptionKey.charAt(0).toUpperCase() + currentOptionKey.slice(1)}=\${config.stores.cookie.options[currentOptionKey]}\`;
-            }, '');
-            
-            const cookieString = \`\${cookieName}=\${cookieValue}\${cookieOptions}\`;
+    let cookies = event.node.res.getHeader('Set-Cookie') || [];
 
-            event.node.res.setHeader('Set-Cookie', cookieString)
-        }
+    const refreshCookieValue = response._data?.[options.strategy?.refreshToken?.property]
+    if (config.stores.cookie.enabled && refreshCookieValue && options.strategy.refreshToken.httpOnly) {
+        const refreshCookie = serialize(refreshCookieName, refreshCookieValue, { ...config.stores.cookie.options, httpOnly: true })
+        cookies.push(refreshCookie);
+    }
 
-        return event.node.res.end(JSON.stringify(response._data))
+    const tokenCookieValue = response._data?.[options.strategy?.token?.property]
+    if (config.stores.cookie.enabled && tokenCookieValue && options.strategy.token.httpOnly) {
+        const token = addTokenPrefix(tokenCookieValue, options.strategy.token.type)
+        const tokenCookie = serialize(tokenCookieName, token, { ...config.stores.cookie.options, httpOnly: true })
+        cookies.push(tokenCookie);
+    }
+
+    if (cookies.length) {
+        event.node.res.setHeader('Set-Cookie', cookies);
+    }
+
+    event.node.res.end(JSON.stringify(response._data))
+})
+`;
+}
+
+export function localAuthorizeGrant(opt: any): string {
+return `import { defineEventHandler, readBody, createError, getCookie } from 'h3'
+import { isIPv6, type AddressInfo } from 'node:net'
+import { config } from '#nuxt-auth-options'
+import { serialize } from 'cookie-es'
+import http from 'node:http'
+
+const options = ${JSON.stringify(opt, null, 4)}
+
+function checkProtocol(url) {
+    const regex = /^(http|https):\\/\\//;
+    if(regex.test(url)) {
+        return true
+    } else {
+        return false
+    }
+}
+
+function addTokenPrefix(token: string | boolean, tokenType: string | false): string | boolean {
+    if (!token || !tokenType || typeof token !== 'string' || token.startsWith(tokenType)) {
+        return token;
+    }
+
+    return tokenType + ' ' + token;
+}
+
+export default defineEventHandler(async (event) => {
+    const requestBody = await readBody(event)
+
+    const refreshCookieName = config.stores.cookie.prefix + options.strategy?.refreshToken?.prefix + options.strategy.name
+    const tokenCookieName = config.stores.cookie.prefix + options.strategy?.token?.prefix + options.strategy.name
+    const serverRefreshToken = getCookie(event, refreshCookieName)
+
+    // Grant type is refresh token, but refresh token is not available
+    if ((requestBody.grant_type === 'refresh_token' && !options.strategy.refreshToken.httpOnly && !requestBody.refresh_token) || (requestBody.grant_type === 'refresh_token' && options.strategy.refreshToken.httpOnly && !serverRefreshToken)) {
+        return createError({
+            statusCode: 500,
+            message: 'Missing refresh token'
+        })
+    }
+
+    let body = {
+        ...requestBody,
+        refresh_token: options.strategy.refreshToken.httpOnly ? serverRefreshToken : requestBody.refresh_token,
+    }
+
+    if (requestBody.grant_type !== 'refresh_token') {
+        delete body.refresh_token
+    }
+
+    const authorizationURL = body.refresh_token ? options.refreshEndpoint : options.tokenEndpoint
+    // @ts-ignore
+    const server = event.node.res.socket?.server as http.Server
+    const addressInfo = server?.address() as AddressInfo
+    const host = addressInfo.address;
+    const port = addressInfo.port;
+    let serverURL;
+
+    if (isIPv6(host)) {
+        serverURL = 'http://[' + host + ']:' + port;
+    } else {
+        serverURL = 'http://' + host + ':' + port;
+    }
+
+    const response = await event.$http.post(authorizationURL, {
+        baseURL: checkProtocol(authorizationURL) ? '' : serverURL,
+        body: new URLSearchParams(body)
     })
-    .catch((error) => {
-        const data = error.response?._data || error.response?.data
-        event.node.res.statusCode = error.response?.status
-        return event.node.res.end(JSON.stringify(data))
-    })
+
+    let cookies = event.node.res.getHeader('Set-Cookie') || [];
+
+    const refreshCookieValue = response._data?.[options.strategy?.refreshToken?.property]
+    if (config.stores.cookie.enabled && refreshCookieValue && options.strategy.refreshToken.httpOnly) {
+        const refreshCookie = serialize(refreshCookieName, refreshCookieValue, { ...config.stores.cookie.options, httpOnly: true })
+        cookies.push(refreshCookie);
+    }
+
+    const tokenCookieValue = response._data?.[options.strategy?.token?.property]
+    if (config.stores.cookie.enabled && tokenCookieValue && options.strategy.token.httpOnly) {
+        const token = addTokenPrefix(tokenCookieValue, options.strategy.token.type)
+        const tokenCookie = serialize(tokenCookieName, token, { ...config.stores.cookie.options, httpOnly: true })
+        cookies.push(tokenCookie);
+    }
+
+    if (cookies.length) {
+        event.node.res.setHeader('Set-Cookie', cookies);
+    }
+
+    event.node.res.end(JSON.stringify(response._data))
 })
 `;
 }
@@ -214,9 +330,8 @@ export default defineEventHandler(async (event) => {
 export function passwordGrant(opt: any): string {
 return `import requrl from 'requrl';
 import { defineEventHandler, readBody, createError } from 'h3';
-import { createInstance } from '@refactorjs/ofetch';
 
-const options = ${JSON.stringify(opt)}
+const options = ${JSON.stringify(opt, null, 4)}
 
 export default defineEventHandler(async (event) => {
     const body = await readBody(event)
@@ -248,9 +363,7 @@ export default defineEventHandler(async (event) => {
         })
     }
 
-    const $fetch = createInstance()
-
-    await $fetch.post(options.tokenEndpoint, {
+    const response = await event.$http.post(options.tokenEndpoint, {
         baseURL: requrl(event.node.req),
         body: {
             client_id: options.clientId,
@@ -261,12 +374,8 @@ export default defineEventHandler(async (event) => {
             Accept: 'application/json'
         }
     })
-    .then((response) => event.node.res.end(JSON.stringify(response._data)))
-    .catch((error) => {
-        const data = error.response?._data || error.response?.data
-        event.node.res.statusCode = error.response?.status
-        event.node.res.end(JSON.stringify(data))
-    })
+
+    event.node.res.end(JSON.stringify(response._data))
 })
 `;
 }


### PR DESCRIPTION
# **Changes & Additions**

### **OAuth2, Local Scheme & Inheritances**
- The `token` and `refreshToken` property for the scheme includes an `httpOnly` property that will enable the httpOnly flag on the token and fresh token cookies. This option is disabled by default. (In a later version it will be enabled by default)

- All schemes (custom & built-in) will use a `serverHandler` if ssr is available to manage the creation of httpOnly cookies and authorization. 

- A reset `serverHandler` has been added to handle the deletion of the httpOnly cookies when logging out/using the reset function

### **nuxt-alt/http**
- A `event.$http` nitro plugin has been added which works similar to what `event.$fetch` does, the difference being that it inherits the options of the http module.
- Fixed issue where using `$http` in nitro would lead to a fetch error.