### PR TITLE
Fix onResponseError chain call

### DIFF
--- a/src/runtime/inc/request-handler.ts
+++ b/src/runtime/inc/request-handler.ts
@@ -105,6 +105,7 @@ export class RequestHandler {
                     this.scheme.reset?.()
                     throw new ExpiredAuthSessionError();
                 }
+                throw error;
             }
         );
     }


### PR DESCRIPTION
Method onResponseError doesn't work (also all `$http.interceptors.response` with errors handlers)

This PR fix problem

## How to reproduce:
- Replace code in `playground/pages/index.vue` with above ($http.get should return 404 error code)
```vue
<template>
    <div>
        <pre>{{ auth.user }}</pre>
        <div>onResponseErrorWork: {{ onResponseErrorWork }}</div>
    </div>
</template>

<script lang="ts" setup>
const { $auth, $http } = useNuxtApp()
const onResponseErrorWork = ref(false);

$http.onResponseError(error => {
    onResponseErrorWork.value = true;
    console.log('onResponseError: ', error)
});

$http.get('http://localhost:3000/unexist-page-123')
const auth = useAuth()
console.log(auth)
console.log($auth)
</script>
```
With fix onResponseErrorWork will be true and console.log will call
Without fix onResponseErrorWork will be false, because onResponseError never called in chain after request handler interceptor
Without fix all calls with `$http.get` and others methods newer throw error (`catch` never «catch»)

