### PR TITLE
v3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Denoder",
@@ -38,6 +38,7 @@
     "dependencies": {
         "@nuxt-alt/http": "latest",
         "@nuxt/kit": "^3.8.2",
+        "@refactorjs/serialize": "latest",
         "cookie-es": "^1.0.0",
         "defu": "^6.1.3",
         "jwt-decode": "^4.0.0",

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,9 +1,10 @@
 import type { ModuleOptions } from './types';
 import { addImports, addPluginTemplate, createResolver, defineNuxtModule, installModule, addRouteMiddleware, addServerHandler } from '@nuxt/kit';
 import { name, version } from '../package.json';
+import { serialize } from '@refactorjs/serialize';
 import { resolveStrategies } from './resolve';
 import { moduleDefaults } from './options';
-import { getAuthPlugin, converter } from './plugin';
+import { getAuthPlugin } from './plugin';
 import { defu } from 'defu';
 
 const CONFIG_KEY = 'auth';
@@ -55,7 +56,7 @@ export default defineNuxtModule({
 
         nuxt.hook('nitro:config', (config) => {
             config.virtual = config.virtual || {}
-            config.virtual['#nuxt-auth-options'] = `export const config = ${JSON.stringify(options, converter, 2)}`
+            config.virtual['#nuxt-auth-options'] = `export const config = ${serialize(options, { space: 4 })}`
         })
 
         // Install http module if not in modules

--- a/src/runtime/providers/laravel-jwt.ts
+++ b/src/runtime/providers/laravel-jwt.ts
@@ -1,7 +1,7 @@
 import type { ProviderPartialOptions, ProviderOptions } from '../../types';
 import type { RefreshSchemeOptions } from '..';
 import type { Nuxt } from '@nuxt/schema';
-import { assignDefaults, assignAbsoluteEndpoints } from '../../utils/provider';
+import { assignDefaults, assignAbsoluteEndpoints, addLocalAuthorize } from '../../utils/provider';
 import { LOCALDEFAULTS } from '../inc';
 
 export interface LaravelJWTProviderOptions extends ProviderOptions, RefreshSchemeOptions {
@@ -53,4 +53,8 @@ export function laravelJWT(nuxt: Nuxt, strategy: ProviderPartialOptions<LaravelJ
     assignDefaults(strategy, DEFAULTS as typeof strategy);
 
     assignAbsoluteEndpoints(strategy);
+
+    if (strategy.ssr) {
+        addLocalAuthorize(nuxt, strategy);
+    }
 }

--- a/src/runtime/providers/laravel-sanctum.ts
+++ b/src/runtime/providers/laravel-sanctum.ts
@@ -7,6 +7,12 @@ import { LOCALDEFAULTS } from '../inc';
 export interface LaravelSanctumProviderOptions extends ProviderOptions, CookieSchemeOptions {}
 
 export function laravelSanctum(nuxt: Nuxt, strategy: ProviderPartialOptions<LaravelSanctumProviderOptions>): void {
+    const { url } = strategy
+
+    if (!url) {
+        throw new Error('URL is required with Laravel Sanctum!')
+    }
+
     const endpointDefaults: Partial<HTTPRequest> = {
         credentials: 'include'
     };
@@ -49,13 +55,9 @@ export function laravelSanctum(nuxt: Nuxt, strategy: ProviderPartialOptions<Lara
     })
 
     assignDefaults(strategy, DEFAULTS as typeof strategy)
+    assignAbsoluteEndpoints(strategy)
 
-    if (strategy.url) {
-        assignAbsoluteEndpoints(strategy)
-    }
-
-    if (strategy.scheme === 'refresh') {
+    if (strategy.ssr) {
         addLocalAuthorize(nuxt, strategy);
     }
-
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -30,7 +30,6 @@ export function addAuthorize<SOptions extends StrategyOptions<Oauth2SchemeOption
         filename: `authorize-${strategy.name}.ts`,
         write: true,
         getContents: () => authorizeGrant({
-            baseURL: nuxt.options.http?.baseURL,
             strategy,
             useForms,
             clientSecret,
@@ -286,25 +285,8 @@ export default defineEventHandler(async (event) => {
     }
 
     const authorizationURL = body.refresh_token ? options.refreshEndpoint : options.tokenEndpoint
-    // @ts-ignore
-    const server = event.node.res.socket?.server as http.Server
-    const addressInfo = server?.address() as AddressInfo
-    const host = addressInfo.address;
-    const port = addressInfo.port;
-    let serverURL;
-
-    if (isIPv6(host)) {
-        serverURL = 'http://[' + host + ']:' + port;
-    } else {
-        serverURL = 'http://' + host + ':' + port;
-    }
-
-    if (!host) {
-        serverURL = options.baseURL
-    }
 
     const response = await event.$http.post(authorizationURL, {
-        baseURL: checkProtocol(authorizationURL) ? '' : serverURL,
         body: new URLSearchParams(body)
     })
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -2,6 +2,7 @@ import type { Oauth2SchemeOptions, RefreshSchemeOptions } from '../runtime';
 import type { StrategyOptions, HTTPRequest, TokenableSchemeOptions } from '../types';
 import type { Nuxt } from '@nuxt/schema';
 import { addServerHandler, addTemplate } from '@nuxt/kit';
+import { serialize } from '@refactorjs/serialize';
 import { join } from 'pathe';
 import { defu } from 'defu';
 
@@ -129,10 +130,11 @@ export function assignAbsoluteEndpoints<SOptions extends StrategyOptions<(Tokena
 
 export function authorizeGrant(opt: any): string {
 return `import { defineEventHandler, readBody, createError, getCookie } from 'h3'
+// @ts-expect-error: virtual file 
 import { config } from '#nuxt-auth-options'
 import { serialize } from 'cookie-es'
 
-const options = ${JSON.stringify(opt, null, 4)}
+const options = ${serialize(opt)}
 
 function addTokenPrefix(token: string | boolean, tokenType: string | false): string | boolean {
     if (!token || !tokenType || typeof token !== 'string' || token.startsWith(tokenType)) {
@@ -236,21 +238,11 @@ export default defineEventHandler(async (event) => {
 
 export function localAuthorizeGrant(opt: any): string {
 return `import { defineEventHandler, readBody, createError, getCookie } from 'h3'
-import { isIPv6, type AddressInfo } from 'node:net'
+// @ts-expect-error: virtual file
 import { config } from '#nuxt-auth-options'
 import { serialize } from 'cookie-es'
-import http from 'node:http'
 
-const options = ${JSON.stringify(opt, null, 4)}
-
-function checkProtocol(url) {
-    const regex = /^(http|https):\\/\\//;
-    if(regex.test(url)) {
-        return true
-    } else {
-        return false
-    }
-}
+const options = ${serialize(opt)}
 
 function addTokenPrefix(token: string | boolean, tokenType: string | false): string | boolean {
     if (!token || !tokenType || typeof token !== 'string' || token.startsWith(tokenType)) {
@@ -318,7 +310,7 @@ export function passwordGrant(opt: any): string {
 return `import requrl from 'requrl';
 import { defineEventHandler, readBody, createError } from 'h3';
 
-const options = ${JSON.stringify(opt, null, 4)}
+const options = ${serialize(opt)}
 
 export default defineEventHandler(async (event) => {
     const body = await readBody(event)


### PR DESCRIPTION
# **Changes & Additions**

### **Auth Core**
- Enforce the use of a url with providers that use the local scheme. This is due to the fact that although the `node-server` preset works without it, other presets don't.
- Moved js serialization to external package