### PR TITLE
fixes refresh scheme

### DIFF
--- a/src/runtime/schemes/refresh.ts
+++ b/src/runtime/schemes/refresh.ts
@@ -148,10 +148,8 @@ export class RefreshScheme<OptionsT extends RefreshSchemeOptions = RefreshScheme
             endpoint.body!.client_id = this.options.clientId;
         }
 
-        // Add grant type to payload if defined
-        if (this.options.grantType) {
-            endpoint.body!.grant_type = 'refresh_token';
-        }
+        // this is required to be set in the provider or it will delete the refresh token
+        endpoint.body!.grant_type = 'refresh_token';
 
         cleanObj(endpoint.body!);
 


### PR DESCRIPTION
includes grant_type 'refresh_token' on all refreshes.
updates local provider to use refreshToken.data attribute if it is included in options, defaults to 'refresh_token' if not.