### PR TITLE
v3.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,24 +37,24 @@
     },
     "dependencies": {
         "@nuxt-alt/http": "latest",
-        "@nuxt/kit": "^3.9.3",
+        "@nuxt/kit": "^3.12.2",
         "@refactorjs/serialize": "latest",
-        "cookie-es": "^1.0.0",
+        "cookie-es": "^1.1.0",
         "defu": "^6.1.3",
         "jwt-decode": "^4.0.0",
         "ohash": "^1.1.3",
-        "pathe": "^1.1.1",
+        "pathe": "^1.1.2",
         "pinia": "^2.1.7",
         "requrl": "^3.0.2"
     },
     "devDependencies": {
-        "@nuxt-alt/proxy": "^2.4.8",
-        "@nuxt/schema": "^3.9.3",
+        "@nuxt-alt/proxy": "^2.5.8",
+        "@nuxt/schema": "^3.12.2",
         "@nuxtjs/i18n": "next",
         "@types/node": "^20",
-        "jiti": "^1.21.0",
+        "jiti": "^1.21.6",
         "nuxt": "^3.9.3",
-        "typescript": "^5.3.3",
+        "typescript": "5.3.3",
         "unbuild": "^2.0.0"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "3.1.7-beta.0",
+    "version": "3.1.7",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Denoder",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nuxt-alt/auth",
-    "version": "3.1.4",
+    "version": "3.1.7-beta.0",
     "description": "An alternative module to @nuxtjs/auth",
     "homepage": "https://github.com/nuxt-alt/auth",
     "author": "Denoder",
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@nuxt-alt/http": "latest",
-        "@nuxt/kit": "^3.9.1",
+        "@nuxt/kit": "^3.9.3",
         "@refactorjs/serialize": "latest",
         "cookie-es": "^1.0.0",
         "defu": "^6.1.3",
@@ -49,11 +49,11 @@
     },
     "devDependencies": {
         "@nuxt-alt/proxy": "^2.4.8",
-        "@nuxt/schema": "^3.9.1",
+        "@nuxt/schema": "^3.9.3",
         "@nuxtjs/i18n": "next",
         "@types/node": "^20",
         "jiti": "^1.21.0",
-        "nuxt": "^3.9.1",
+        "nuxt": "^3.9.3",
         "typescript": "^5.3.3",
         "unbuild": "^2.0.0"
     },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,10 @@
-import type { ModuleOptions, Strategy, ImportOptions } from './types';
+import type { ModuleOptions, StrategyOptions, ImportOptions } from './types';
 import { serialize } from '@refactorjs/serialize';
 
 export const getAuthPlugin = (options: {
     options: ModuleOptions
     schemeImports: ImportOptions[]
-    strategies: Strategy[]
+    strategies: StrategyOptions[]
     strategyScheme: Record<string, ImportOptions>
 }): string => {
     return `import { Auth, ExpiredAuthSessionError } from '#auth/runtime'

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,4 +1,4 @@
-import type { StrategyOptions, ModuleOptions, ProviderNames, SchemeNames, ImportOptions } from './types';
+import type { StrategyOptions, ModuleOptions, SchemeNames, ImportOptions } from './types';
 import type { Nuxt } from '@nuxt/schema';
 import { OAUTH2DEFAULTS, LOCALDEFAULTS, ProviderAliases, BuiltinSchemes, LocalSchemes, OAuth2Schemes } from './runtime/inc/default-properties';
 import { addAuthorize, addLocalAuthorize, assignAbsoluteEndpoints, assignDefaults, } from './utils/provider';

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,23 +1,24 @@
-import type { Strategy, ModuleOptions, ProviderNames, SchemeNames, ImportOptions } from './types';
+import type { StrategyOptions, ModuleOptions, ProviderNames, SchemeNames, ImportOptions } from './types';
 import type { Nuxt } from '@nuxt/schema';
-import { OAUTH2DEFAULTS, LOCALDEFAULTS, ProviderAliases, BuiltinSchemes } from './runtime/inc/default-properties';
-import { addAuthorize, addLocalAuthorize, assignAbsoluteEndpoints, assignDefaults } from './utils/provider';
+import { OAUTH2DEFAULTS, LOCALDEFAULTS, ProviderAliases, BuiltinSchemes, LocalSchemes, OAuth2Schemes } from './runtime/inc/default-properties';
+import { addAuthorize, addLocalAuthorize, assignAbsoluteEndpoints, assignDefaults, } from './utils/provider';
+import { hasOwn } from './utils';
 import * as AUTH_PROVIDERS from './runtime/providers';
 import { resolvePath } from '@nuxt/kit';
 import { existsSync } from 'fs';
 import { hash } from 'ohash';
 
 export async function resolveStrategies(nuxt: Nuxt, options: ModuleOptions) {
-    const strategies: Strategy[] = [];
+    const strategies: StrategyOptions[] = [];
     const strategyScheme = {} as Record<string, ImportOptions>;
 
     for (const name of Object.keys(options.strategies!)) {
-        if (!options.strategies![name] || (options.strategies as Strategy)[name].enabled === false) {
+        if (!options.strategies?.[name] || options.strategies?.[name].enabled === false) {
             continue;
         }
 
         // Clone strategy
-        const strategy = Object.assign({}, options.strategies![name]) as Strategy;
+        const strategy = Object.assign({}, options.strategies![name]);
 
         // Default name
         if (!strategy.name) {
@@ -26,14 +27,18 @@ export async function resolveStrategies(nuxt: Nuxt, options: ModuleOptions) {
 
         // Default provider (same as name)
         if (!strategy.provider) {
-            strategy.provider = strategy.name as ProviderNames;
+            strategy.provider = strategy.name;
         }
 
         // Determine if SSR is enabled
-        strategy.ssr = nuxt.options.ssr
+        if (hasOwn(strategy, 'ssr')) {
+            strategy.ssr = strategy.ssr;
+        } else {
+            strategy.ssr = nuxt.options.ssr;
+        }
 
         // Try to resolve provider
-        const provider = await resolveProvider(strategy.provider, nuxt, strategy);
+        const provider = await resolveProvider(strategy.provider as string, nuxt, strategy);
 
         delete strategy.provider;
 
@@ -50,7 +55,7 @@ export async function resolveStrategies(nuxt: Nuxt, options: ModuleOptions) {
             // Resolve and keep scheme needed for strategy
             const schemeImport = await resolveScheme(strategy.scheme);
             delete strategy.scheme;
-            strategyScheme[strategy.name] = schemeImport as ImportOptions;
+            strategyScheme[strategy.name] = schemeImport!;
 
             // Add strategy to array
             strategies.push(strategy);
@@ -90,7 +95,7 @@ export async function resolveScheme(scheme: string) {
     }
 }
 
-export async function resolveProvider(provider: string | ((...args: any[]) => any), nuxt: Nuxt, strategy: Strategy) {
+export async function resolveProvider(provider: string | ((nuxt: Nuxt, strategy: StrategyOptions, ...args: any[]) => void), nuxt: Nuxt, strategy: StrategyOptions) {
     provider = (ProviderAliases[provider as keyof typeof ProviderAliases] || provider);
 
     if (AUTH_PROVIDERS[provider as keyof typeof AUTH_PROVIDERS]) {
@@ -104,20 +109,20 @@ export async function resolveProvider(provider: string | ((...args: any[]) => an
 
     // return an empty function as it doesn't use a provider
     if (typeof provider === 'string') {
-        return (nuxt: Nuxt, strategy: Strategy) => {
-            if (['oauth2', 'openIDConnect', 'auth0'].includes(strategy.scheme!) && strategy.ssr) {
-                assignDefaults(strategy as any, OAUTH2DEFAULTS)
-                addAuthorize(nuxt, strategy as any, true)
+        return (nuxt: Nuxt, strategy: StrategyOptions) => {
+            if (OAuth2Schemes.includes(strategy.scheme!) && strategy.ssr) {
+                assignDefaults(strategy, OAUTH2DEFAULTS as typeof strategy)
+                addAuthorize(nuxt, strategy, true)
             }
 
-            if (['refresh', 'local', 'cookie'].includes(strategy.scheme!) && strategy.ssr) {
-                assignDefaults(strategy as any, LOCALDEFAULTS)
+            if (LocalSchemes.includes(strategy.scheme!) && strategy.ssr) {
+                assignDefaults(strategy, LOCALDEFAULTS as typeof strategy)
 
                 if (strategy.url) {
-                    assignAbsoluteEndpoints(strategy as any);
+                    assignAbsoluteEndpoints(strategy);
                 }
 
-                addLocalAuthorize(nuxt, strategy as any)
+                addLocalAuthorize(nuxt, strategy)
             }
         }
     }

--- a/src/runtime/inc/default-properties.ts
+++ b/src/runtime/inc/default-properties.ts
@@ -116,9 +116,22 @@ export const ProviderAliases = {
 export const BuiltinSchemes = {
     local: 'LocalScheme',
     cookie: 'CookieScheme',
-    oauth2: 'Oauth2Scheme',
-    openIDConnect: 'OpenIDConnectScheme',
     refresh: 'RefreshScheme',
     laravelJWT: 'LaravelJWTScheme',
+    oauth2: 'Oauth2Scheme',
+    openIDConnect: 'OpenIDConnectScheme',
     auth0: 'Auth0Scheme',
 };
+
+export const LocalSchemes = [
+    'local',
+    'cookie',
+    'refresh',
+    'laravelJWT',
+]
+
+export const OAuth2Schemes = [
+    'oauth',
+    'openIDConnect',
+    'auth0',
+]

--- a/src/runtime/inc/id-token.ts
+++ b/src/runtime/inc/id-token.ts
@@ -36,14 +36,13 @@ export class IdToken {
     }
 
     reset() {
-        this.scheme.requestHandler!.clearHeader();
         this.#resetSSRToken();
         this.#setToken(undefined);
         this.#setExpiration(undefined);
     }
 
     status(): TokenStatus {
-        return new TokenStatus(this.get(), this.#getExpiration());
+        return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.idToken?.httpOnly);
     }
 
     #resetSSRToken(): void {

--- a/src/runtime/inc/refresh-token.ts
+++ b/src/runtime/inc/refresh-token.ts
@@ -36,13 +36,13 @@ export class RefreshToken {
     }
 
     reset(): void {
-        this.#resetSSRToken()
+        this.#resetSSRToken();
         this.#setToken(undefined);
         this.#setExpiration(undefined);
     }
 
     status(): TokenStatus {
-        return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.refreshToken.httpOnly);
+        return new TokenStatus(this.get(), this.#getExpiration(), this.scheme.options.refreshToken?.httpOnly);
     }
 
     #resetSSRToken(): void {

--- a/src/runtime/inc/request-handler.ts
+++ b/src/runtime/inc/request-handler.ts
@@ -17,7 +17,7 @@ export class RequestHandler {
         this.auth = auth;
         this.requestInterceptor = null;
         this.responseErrorInterceptor = null;
-        this.currentToken = this.auth.$storage.memory.value?.[this.scheme.options.token!.prefix + this.scheme.options.name] as string
+        this.currentToken = this.auth.$storage?.memory?.[this.scheme.options.token!?.prefix + this.scheme.options.name] as string
     }
 
     setHeader(token: string): void {

--- a/src/runtime/schemes/auth0.ts
+++ b/src/runtime/schemes/auth0.ts
@@ -2,7 +2,7 @@ import { withQuery } from 'ufo';
 import { Oauth2Scheme } from '../schemes/oauth2';
 
 export class Auth0Scheme extends Oauth2Scheme {
-    logout(): void {
+    override logout(): void {
         this.$auth.reset();
 
         const opts = {

--- a/src/runtime/schemes/cookie.ts
+++ b/src/runtime/schemes/cookie.ts
@@ -45,7 +45,7 @@ export class CookieScheme<OptionsT extends CookieSchemeOptions> extends LocalSch
         super($auth, options as OptionsT, DEFAULTS as OptionsT);
     }
 
-    async mounted(): Promise<HTTPResponse<any> | void> {
+    override async mounted(): Promise<HTTPResponse<any> | void> {
         if (process.server) {
             this.$auth.ctx.$http.setHeader('referer', this.$auth.ctx.ssrContext!.event.node.req.headers.host!);
         }
@@ -59,7 +59,7 @@ export class CookieScheme<OptionsT extends CookieSchemeOptions> extends LocalSch
         return this.$auth.fetchUserOnce();
     }
 
-    check(): SchemeCheck {
+    override check(): SchemeCheck {
         const response = { valid: false };
 
         if (!super.check().valid && this.options.token?.type) {
@@ -82,7 +82,7 @@ export class CookieScheme<OptionsT extends CookieSchemeOptions> extends LocalSch
         return response;
     }
 
-    async login(endpoint: HTTPRequest): Promise<HTTPResponse<any> | void> {
+    override async login(endpoint: HTTPRequest): Promise<HTTPResponse<any> | void> {
         // Ditch any leftover local tokens before attempting to log in
         this.$auth.reset();
 
@@ -119,7 +119,7 @@ export class CookieScheme<OptionsT extends CookieSchemeOptions> extends LocalSch
         return response;
     }
 
-    async fetchUser(endpoint?: HTTPRequest): Promise<HTTPResponse<any> | void> {
+    override async fetchUser(endpoint?: HTTPRequest): Promise<HTTPResponse<any> | void> {
         if (!this.check().valid) {
             return Promise.resolve();
         }
@@ -156,7 +156,7 @@ export class CookieScheme<OptionsT extends CookieSchemeOptions> extends LocalSch
             });
     }
 
-    reset(): void {
+    override reset(): void {
         if (this.options.cookie.name) {
             this.$auth.$storage.setCookie(this.options.cookie.name, null);
         }

--- a/src/runtime/schemes/laravel-jwt.ts
+++ b/src/runtime/schemes/laravel-jwt.ts
@@ -2,7 +2,7 @@ import type { HTTPResponse } from '../../types';
 import { RefreshScheme } from './refresh';
 
 export class LaravelJWTScheme extends RefreshScheme {
-    protected updateTokens(response: HTTPResponse<any>): void {
+    protected override updateTokens(response: HTTPResponse<any>): void {
         super.updateTokens(response);
     }
 }

--- a/src/runtime/schemes/local.ts
+++ b/src/runtime/schemes/local.ts
@@ -128,6 +128,7 @@ export class LocalScheme<OptionsT extends LocalSchemeOptions = LocalSchemeOption
             this.$auth.reset({ resetInterceptor: false });
         }
 
+        endpoint = endpoint || {};
         endpoint.body = endpoint.body || {};
 
         // Add client id to payload if defined

--- a/src/runtime/schemes/openIDConnect.ts
+++ b/src/runtime/schemes/openIDConnect.ts
@@ -1,6 +1,5 @@
 import type { HTTPResponse, SchemeCheck, SchemePartialOptions } from '../../types';
 import type { Auth } from '..';
-import type { Router } from 'vue-router';
 import { Oauth2Scheme, type Oauth2SchemeEndpoints, type Oauth2SchemeOptions } from './oauth2';
 import { normalizePath, getProp, parseQuery } from '../../utils';
 import { IdToken, ConfigurationDocument } from '../inc';
@@ -46,7 +45,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
         this.configurationDocument = new ConfigurationDocument(this, this.$auth.$storage);
     }
 
-    protected updateTokens(response: HTTPResponse<any>): void {
+    protected override updateTokens(response: HTTPResponse<any>): void {
         super.updateTokens(response);
         const idToken = getProp(response._data, this.options.idToken.property) as string;
 
@@ -55,7 +54,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
         }
     }
 
-    check(checkStatus = false): SchemeCheck {
+    override check(checkStatus = false): SchemeCheck {
         const response: SchemeCheck = {
             valid: false,
             tokenExpired: false,
@@ -107,7 +106,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
         return response;
     }
 
-    async mounted() {
+    override async mounted() {
         // Get and validate configuration based upon OpenIDConnect Configuration document
         // https://openid.net/specs/openid-connect-configuration-1_0.html
         await this.configurationDocument.init();
@@ -131,7 +130,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
         }
     }
 
-    reset() {
+    override reset() {
         this.$auth.setUser(false);
         this.token.reset();
         this.idToken.reset();
@@ -140,7 +139,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
         this.configurationDocument.reset();
     }
 
-    logout() {
+    override logout() {
         if (this.options.endpoints.logout) {
             const opts: QueryObject = {
                 id_token_hint: this.idToken.get() as QueryValue,
@@ -152,7 +151,7 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
         return this.$auth.reset();
     }
 
-    async fetchUser() {
+    override async fetchUser() {
         if (!this.check().valid) {
             return;
         }

--- a/src/runtime/schemes/refresh.ts
+++ b/src/runtime/schemes/refresh.ts
@@ -49,7 +49,7 @@ export class RefreshScheme<OptionsT extends RefreshSchemeOptions = RefreshScheme
         this.refreshController = new RefreshController(this);
     }
 
-    check(checkStatus = false): SchemeCheck {
+    override check(checkStatus = false): SchemeCheck {
         const response = {
             valid: false,
             tokenExpired: false,
@@ -92,7 +92,7 @@ export class RefreshScheme<OptionsT extends RefreshSchemeOptions = RefreshScheme
         return response;
     }
 
-    mounted(): Promise<HTTPResponse<any> | void> {
+    override mounted(): Promise<HTTPResponse<any> | void> {
         return super.mounted({
             tokenCallback: () => {
                 if (this.options.autoLogout) {
@@ -162,7 +162,7 @@ export class RefreshScheme<OptionsT extends RefreshSchemeOptions = RefreshScheme
         this.updateTokens(response);
     }
 
-    setUserToken(token: string | boolean, refreshToken?: string | boolean): Promise<HTTPResponse<any> | void> {
+    override setUserToken(token: string | boolean, refreshToken?: string | boolean): Promise<HTTPResponse<any> | void> {
         this.token.set(token);
 
         if (refreshToken) {
@@ -173,7 +173,7 @@ export class RefreshScheme<OptionsT extends RefreshSchemeOptions = RefreshScheme
         return this.fetchUser();
     }
 
-    reset({ resetInterceptor = true } = {}): void {
+    override reset({ resetInterceptor = true } = {}): void {
         this.$auth.setUser(false);
         this.token.reset();
         this.refreshToken.reset();
@@ -187,7 +187,7 @@ export class RefreshScheme<OptionsT extends RefreshSchemeOptions = RefreshScheme
         return getProp(response._data, this.options.refreshToken.property) as string
     }
 
-    protected updateTokens(response: HTTPResponse<any>): void {
+    protected override updateTokens(response: HTTPResponse<any>): void {
         let tokenExpiresIn: number | boolean = false
         const token = this.options.token?.required ? this.extractToken(response) : true;
         const refreshToken = this.options.refreshToken.required ? this.extractRefreshToken(response) : true;
@@ -200,7 +200,7 @@ export class RefreshScheme<OptionsT extends RefreshSchemeOptions = RefreshScheme
         }
     }
 
-    protected initializeRequestInterceptor(): void {
+    protected override initializeRequestInterceptor(): void {
         this.requestHandler.initializeRequestInterceptor(
             this.options.endpoints.refresh.url
         );

--- a/src/runtime/token-nitro.ts
+++ b/src/runtime/token-nitro.ts
@@ -1,4 +1,5 @@
 import { readBody, defineEventHandler, deleteCookie } from 'h3'
+// @ts-expect-error: virtual file
 import { config } from '#nuxt-auth-options'
 
 export default defineEventHandler(async (event) => {

--- a/src/types/options.d.ts
+++ b/src/types/options.d.ts
@@ -1,4 +1,4 @@
-import type { Strategy } from './strategy';
+import type { Strategy, StrategyOptions } from './strategy';
 import type { NuxtPlugin } from '@nuxt/schema';
 import type { AuthState, RefreshableScheme, TokenableScheme } from './index';
 import type { CookieSerializeOptions } from 'cookie-es';
@@ -24,7 +24,7 @@ export interface ModuleOptions {
     /**
      * Authentication strategies used by the module.
      */
-    strategies?: Record<string, Strategy>;
+    strategies?: Record<string, StrategyOptions>;
 
     /**
      * Whether exceptions should be ignored or not.

--- a/src/types/provider.d.ts
+++ b/src/types/provider.d.ts
@@ -1,7 +1,9 @@
-import type { SchemeOptions } from './scheme';
+import type { SchemeOptions, SchemeNames } from './scheme';
+import type { StrategyOptions } from './strategy';
 import type { PartialExcept } from './utils';
+import type { Nuxt } from '@nuxt/schema';
 
-export type ProviderNames<N = ''> = 'laravel/sanctum' | 'laravel/jwt' | 'laravel/passport' | 'google' | 'github' | 'facebook' | 'discord' | 'auth0' | N | ((...args: any[]) => any)
+export type ProviderNames<N = ''> = 'laravel/sanctum' | 'laravel/jwt' | 'laravel/passport' | 'google' | 'github' | 'facebook' | 'discord' | 'auth0' | N | ((nuxt: Nuxt, strategy: StrategyOptions, ...args: any[]) => void);
 
 export interface ImportOptions {
     name: string;
@@ -10,7 +12,7 @@ export interface ImportOptions {
 }
 
 export interface ProviderOptions {
-    scheme: string;
+    scheme?: SchemeNames;
     clientSecret: string | number;
 }
 

--- a/src/types/strategy.d.ts
+++ b/src/types/strategy.d.ts
@@ -1,17 +1,16 @@
 import type { SchemePartialOptions, RefreshableSchemeOptions, SchemeOptions, SchemeNames } from './scheme';
 import type { CookieSchemeOptions, Oauth2SchemeOptions, OpenIDConnectSchemeOptions } from '../runtime/schemes';
 import type { ProviderPartialOptions, ProviderOptions, ProviderNames } from './provider';
+import type { RecursivePartial } from './utils';
 
 export type Strategy<S = {}> = S & Strategies;
 
 // @ts-ignore: endpoints dont match
 export interface AuthSchemeOptions extends RefreshableSchemeOptions, Oauth2SchemeOptions, CookieSchemeOptions, OpenIDConnectSchemeOptions {}
 
-export interface Strategies extends SchemePartialOptions<AuthSchemeOptions> {
-    provider?: ProviderNames | ((...args: any[]) => any);
-    scheme?: SchemeNames;
+export interface Strategies {
+    provider?: ProviderNames;
     enabled?: boolean;
-    [key: string]: any;
 }
 
-export type StrategyOptions<SOptions extends SchemeOptions = SchemeOptions> = ProviderPartialOptions<ProviderOptions & SOptions>;
+export type StrategyOptions<SOptions extends RecursivePartial<AuthSchemeOptions> = RecursivePartial<AuthSchemeOptions>> = ProviderPartialOptions<ProviderOptions & SOptions & Strategy>;


### PR DESCRIPTION
# **Changes & Additions**

### **TypeScript**
- Internal typescript fixes for strategies (v3.1.7)
- Basic descriptions for module options (since v3.1.5)

### **Auth Core**
- Apply Fix for: https://github.com/nuxt-alt/auth/discussions/106 (v3.1.7)
- Allow headers to be set via endpoints for local scheme and its inheritances (since v3.1.6)
- Revert: Pinia needs to be defined in storage in order for the `@pinia/nuxt` plugin to function properly. Maybe the best option here would be to have the user define their own pinia store then use that internally rather than the module making the store. (since v3.1.5)

### **nuxt-alt/http**
- `onUploadProgress`/`onDownloadProgress` added
- fix: `$http` in nitro getting overridden by nuxt plugin in server instance