### PR TITLE
fix: add custom string path to SchemeNames types

### DIFF
--- a/src/types/scheme.d.ts
+++ b/src/types/scheme.d.ts
@@ -3,7 +3,7 @@ import type { Auth } from '../runtime/core';
 import type { Token, IdToken, RefreshToken, RefreshController, RequestHandler } from '../runtime/inc';
 import type { PartialExcept } from './utils';
 
-export type SchemeNames<N = ''> = 'local' | 'cookie' | 'laravelJWT' | 'openIDConnect' | 'refresh' | 'oauth2' | 'auth0' | N
+export type SchemeNames<N = ''> = 'local' | 'cookie' | 'laravelJWT' | 'openIDConnect' | 'refresh' | 'oauth2' | 'auth0' | `~/${string}` | N
 
 export interface UserOptions {
     property: string | false;


### PR DESCRIPTION
## Changes and Additions
- Added `~/${string}` to `SchemeNames` types so that custom scheme paths do not throw TS type error when adding them like suggested in the docs

This fixes issue #124 