### PR TITLE
chore: allow usage with nuxt 4

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,7 @@ export default defineNuxtModule({
         version,
         configKey: CONFIG_KEY,
         compatibility: {
-            nuxt: '^3.0.0 || ^4.0.0',
+            nuxt: '>=3.0.0 <5.0.0',
         },
     },
     defaults: ({ options }) => ({

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,7 @@ export default defineNuxtModule({
         version,
         configKey: CONFIG_KEY,
         compatibility: {
-            nuxt: '^3.0.0',
+            nuxt: '^3.0.0 || ^4.0.0',
         },
     },
     defaults: ({ options }) => ({


### PR DESCRIPTION
This seems to work without issues. There is a warning to upgrade nuxt/kit as well, but that can maybe wait until the pre-release stage is complete.